### PR TITLE
Add spaces to macros fixing compilation in C++11

### DIFF
--- a/wintasee/hooks/inputhooks.cpp
+++ b/wintasee/hooks/inputhooks.cpp
@@ -1343,7 +1343,7 @@ return MMSYSERR_NODRIVER; // NYI
 	char threadTypeName[64];
 	sprintf(threadTypeName, "JoypadThread(%d)", uJoyID);
 	tls.curThreadCreateName = threadTypeName;
-debuglog(LCF_JOYPAD|LCF_UNTESTED, "in "__FUNCTION__", tls.curThreadCreateName = %s\n", tls.curThreadCreateName);
+debuglog(LCF_JOYPAD|LCF_UNTESTED, "in " __FUNCTION__ ", tls.curThreadCreateName = %s\n", tls.curThreadCreateName);
 
 	MMRESULT rv = joyGetPosEx(uJoyID, pji);
 

--- a/wintasee/intercept.h
+++ b/wintasee/intercept.h
@@ -24,7 +24,7 @@
 	static int x__ = 0; \
 	x__++; \
 	x__++; \
-	if(x__==2){debugprintf("Function \""__FUNCTION__"\" got called before it was set up!"); _asm{int 3} MessageBox(NULL, "Failed to hook function \""__FUNCTION__"\". This should never happen.", "Error", MB_ICONERROR);} \
+	if(x__==2){debugprintf("Function '" __FUNCTION__ "' got called before it was set up!"); _asm{int 3} MessageBox(NULL, "Failed to hook function '" __FUNCTION__ "'. This should never happen.", "Error", MB_ICONERROR);} \
 	x__++; \
 	x__++;
 #define INTERNAL_TRAMPOLINE_DEF { TRAMPOLINE_CONTENTS return 0; }


### PR DESCRIPTION
MSVC 2015 adds better support for C++11 which breaks "__FUNCTION

See http://stackoverflow.com/q/31738796/745719 for more info
