### PR TITLE
DLL: Cleaned up debugprintf

### DIFF
--- a/wintasee/dettime.cpp
+++ b/wintasee/dettime.cpp
@@ -27,14 +27,14 @@ extern int lastSetTickValue;
 	void NonDeterministicTimer::ExitFrameBoundary()
 	{
 		debuglog(LCF_TIMEGET|LCF_FREQUENT, __FUNCTION__ " called.\n");
-		//timedebugprintf(__FUNCTION__ " called.\n");
+		//TIME_ENTER();
 		lastExitTime = timeGetTime();
 	}
 	void NonDeterministicTimer::EnterFrameBoundary(DWORD framesPerSecond)
 	{
 		debuglog(LCF_TIMEGET|LCF_FREQUENT, __FUNCTION__ "(%d) called.\n", framesPerSecond);
 
-		//timedebugprintf(__FUNCTION__ " called.\n");
+		//TIME_ENTER();
 		lastEnterTime = timeGetTime();
 
 		GetTicks();
@@ -43,7 +43,7 @@ extern int lastSetTickValue;
 	}
 	void NonDeterministicTimer::Initialize(DWORD startTicks)
 	{
-		//timedebugprintf(__FUNCTION__ " called.\n");
+		//TIME_ENTER();
 		ticks = startTicks;
 		lastEnterTicks = startTicks;
 		lasttime = timeGetTime();
@@ -61,7 +61,7 @@ extern int lastSetTickValue;
 		ticksAddedSinceLastFrame = 0;
 		replaceReserveUsed = 0;
 
-		//timedebugprintf(__FUNCTION__ " called.\n");
+		//TIME_ENTER();
 		if(tasflags.framerate <= 0)
 			return nonDetTimer.ExitFrameBoundary(); // 0 framerate means disable deterministic timer
 
@@ -84,7 +84,7 @@ extern int lastSetTickValue;
 	void DeterministicTimer::EnterFrameBoundary(DWORD framesPerSecond)
 	{
 		debuglog(LCF_TIMEGET|LCF_FREQUENT, __FUNCTION__ "(%d) called.\n", framesPerSecond);
-		//timedebugprintf(__FUNCTION__ " called.\n");
+		//TIME_ENTER();
 		if(tasflags.framerate <= 0)
 			return nonDetTimer.EnterFrameBoundary(framesPerSecond); // 0 framerate means disable deterministic timer
 
@@ -243,7 +243,7 @@ int getCurrentFramestampLogical();
 	}
 //	void SleepAndAccumulateOutput(DWORD sleepTicks, BOOL doSleep) // sync hack, usually not used (except when waitSyncMode is 2)
 //	{
-//		timedebugprintf(__FUNCTION__ " (%d, %d) called.", sleepTicks, doSleep);
+//		TIME_ENTER(sleepTicks, doSleep);
 //	
 //		// add sleep time
 //		if(doSleep && !tasflags.fastForward)
@@ -319,7 +319,7 @@ int getCurrentFramestampLogical();
 	}
 	void DeterministicTimer::Initialize(DWORD startTicks)
 	{
-		timedebugprintf(__FUNCTION__ " called.\n");
+		TIME_ENTER();
 		InitializeWithoutDependencies(startTicks);
 		lastEnterTime = timeGetTime();
 		OnSystemTimerRecalibrated(); // in case

--- a/wintasee/hooks/d3d8hooks.cpp
+++ b/wintasee/hooks/d3d8hooks.cpp
@@ -134,7 +134,7 @@ struct MyDirect3DDevice8
 	static ULONG(STDMETHODCALLTYPE *Release)(IDirect3DDevice8* pThis);
 	static ULONG STDMETHODCALLTYPE MyRelease(IDirect3DDevice8* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		ULONG rv = Release(pThis);
 		if(rv == 0)
 		{
@@ -147,7 +147,7 @@ struct MyDirect3DDevice8
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DDevice8* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DDevice8* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -157,7 +157,7 @@ struct MyDirect3DDevice8
 	static HRESULT(STDMETHODCALLTYPE *Reset)(IDirect3DDevice8* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters);
 	static HRESULT STDMETHODCALLTYPE MyReset(IDirect3DDevice8* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams8(pPresentationParameters, NULL, pThis);
 		d3d8BackBufActive = true;
 		d3d8BackBufDirty = true;
@@ -231,7 +231,7 @@ struct MyDirect3DDevice8
 	static HRESULT(STDMETHODCALLTYPE *Present)(IDirect3DDevice8* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion);
 	static HRESULT STDMETHODCALLTYPE MyPresent(IDirect3DDevice8* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 
 		HRESULT rv;
 		if(ShouldSkipDrawing(d3d8BackBufDirty, !d3d8BackBufDirty))
@@ -262,7 +262,7 @@ struct MyDirect3DDevice8
 	static HRESULT(STDMETHODCALLTYPE *CreateAdditionalSwapChain)(IDirect3DDevice8* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DSwapChain8** pSwapChain);
 	static HRESULT STDMETHODCALLTYPE MyCreateAdditionalSwapChain(IDirect3DDevice8* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DSwapChain8** pSwapChain)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams8(pPresentationParameters, NULL, pThis);
 		HRESULT rv = CreateAdditionalSwapChain(pThis, pPresentationParameters, pSwapChain);
 		if(SUCCEEDED(rv))
@@ -283,7 +283,7 @@ struct MyDirect3DDevice8
 	static HRESULT(STDMETHODCALLTYPE *SetRenderTarget)(IDirect3DDevice8* pThis, IDirect3DSurface8* pRenderTarget,IDirect3DSurface8* pNewZStencil);
 	static HRESULT STDMETHODCALLTYPE MySetRenderTarget(IDirect3DDevice8* pThis, IDirect3DSurface8* pRenderTarget,IDirect3DSurface8* pNewZStencil)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pRenderTarget);
+		D3D_ENTER(pRenderTarget);
 		HRESULT rv = SetRenderTarget(pThis, pRenderTarget, pNewZStencil);
 		IDirect3DSurface8* pBackBuffer;
 		if(SUCCEEDED(pThis->GetBackBuffer(0,D3DBACKBUFFER_TYPE_MONO,&pBackBuffer)))
@@ -302,7 +302,7 @@ struct MyDirect3DDevice8
 
 	static void Lock(IDirect3DDevice8* pThis, DDSURFACEDESC& desc, IDirect3DSurface8*& pBackBuffer, CONST RECT* pSourceRect=NULL, bool getBackBuffer=true)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(getBackBuffer)
 			pThis->GetBackBuffer(0,D3DBACKBUFFER_TYPE_MONO,&pBackBuffer);
 
@@ -355,7 +355,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *CopyRects)(IDirect3DDevice8* pThis, IDirect3DSurface8* pSourceSurface,CONST RECT* pSourceRectsArray,UINT cRects,IDirect3DSurface8* pDestinationSurface,CONST POINT* pDestPointsArray);
     static HRESULT STDMETHODCALLTYPE MyCopyRects(IDirect3DDevice8* pThis, IDirect3DSurface8* pSourceSurface,CONST RECT* pSourceRectsArray,UINT cRects,IDirect3DSurface8* pDestinationSurface,CONST POINT* pDestPointsArray)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = CopyRects(pThis, pSourceSurface,pSourceRectsArray,cRects,pDestinationSurface,pDestPointsArray);
 		IDirect3DSurface8* pBuffer;
 		if(!redrawingScreen)
@@ -376,7 +376,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *Clear)(IDirect3DDevice8* pThis, DWORD Count,CONST D3DRECT* pRects,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil);
     static HRESULT STDMETHODCALLTYPE MyClear(IDirect3DDevice8* pThis, DWORD Count,CONST D3DRECT* pRects,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = Clear(pThis, Count,pRects,Flags,Color,Z,Stencil);
@@ -388,7 +388,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *DrawPrimitive)(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT StartVertex,UINT PrimitiveCount);
     static HRESULT STDMETHODCALLTYPE MyDrawPrimitive(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT StartVertex,UINT PrimitiveCount)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawPrimitive(pThis, PrimitiveType,StartVertex,PrimitiveCount);
@@ -400,7 +400,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *DrawIndexedPrimitive)(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE primitiveType,UINT minIndex,UINT NumVertices,UINT startIndex,UINT primCount);
     static HRESULT STDMETHODCALLTYPE MyDrawIndexedPrimitive(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE primitiveType,UINT minIndex,UINT NumVertices,UINT startIndex,UINT primCount)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawIndexedPrimitive(pThis, primitiveType,minIndex,NumVertices,startIndex,primCount);
@@ -412,7 +412,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *DrawPrimitiveUP)(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT PrimitiveCount,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride);
     static HRESULT STDMETHODCALLTYPE MyDrawPrimitiveUP(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT PrimitiveCount,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawPrimitiveUP(pThis, PrimitiveType,PrimitiveCount,pVertexStreamZeroData,VertexStreamZeroStride);
@@ -424,7 +424,7 @@ struct MyDirect3DDevice8
     static HRESULT(STDMETHODCALLTYPE *DrawIndexedPrimitiveUP)(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT MinVertexIndex,UINT NumVertexIndices,UINT PrimitiveCount,CONST void* pIndexData,D3DFORMAT IndexDataFormat,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride);
     static HRESULT STDMETHODCALLTYPE MyDrawIndexedPrimitiveUP(IDirect3DDevice8* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT MinVertexIndex,UINT NumVertexIndices,UINT PrimitiveCount,CONST void* pIndexData,D3DFORMAT IndexDataFormat,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawIndexedPrimitiveUP(pThis, PrimitiveType,MinVertexIndex,NumVertexIndices,PrimitiveCount,pIndexData,IndexDataFormat,pVertexStreamZeroData,VertexStreamZeroStride);
@@ -478,7 +478,7 @@ struct MyDirect3DDevice8
 	//static HRESULT(STDMETHODCALLTYPE *CreateImageSurface)(IDirect3DDevice8* pThis, UINT Width,UINT Height,D3DFORMAT Format,IDirect3DSurface8** ppSurface);
 	//static HRESULT STDMETHODCALLTYPE MyCreateImageSurface(IDirect3DDevice8* pThis, UINT Width,UINT Height,D3DFORMAT Format,IDirect3DSurface8** ppSurface)
 	//{
-	//	d3ddebugprintf(__FUNCTION__ " called.\n");
+	//	D3D_ENTER();
 	//	HRESULT rv = CreateImageSurface(pThis,Width,Height,Format,ppSurface);
 	//	return rv;
 	//}
@@ -519,7 +519,7 @@ struct MyDirect3DSwapChain8
 	static ULONG(STDMETHODCALLTYPE *Release)(IDirect3DSwapChain8* pThis);
 	static ULONG STDMETHODCALLTYPE MyRelease(IDirect3DSwapChain8* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		ULONG rv = Release(pThis);
 		if(rv == 0)
 		{
@@ -531,7 +531,7 @@ struct MyDirect3DSwapChain8
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DSwapChain8* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DSwapChain8* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -541,7 +541,7 @@ struct MyDirect3DSwapChain8
 	static HRESULT(STDMETHODCALLTYPE *Present)(IDirect3DSwapChain8* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion);
 	static HRESULT STDMETHODCALLTYPE MyPresent(IDirect3DSwapChain8* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 
 		HRESULT rv;
 		if(ShouldSkipDrawing(true, false))
@@ -652,7 +652,7 @@ struct MyDirect3DSurface8
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DSurface8* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DSurface8* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		D3D_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -662,7 +662,7 @@ struct MyDirect3DSurface8
 	static HRESULT(STDMETHODCALLTYPE *UnlockRect)(IDirect3DSurface8* pThis);
 	static HRESULT STDMETHODCALLTYPE MyUnlockRect(IDirect3DSurface8* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		HRESULT rv = UnlockRect(pThis);
 		IDirect3DSurface8_CustomData& surf8 = surface8data[pThis];
 		surf8.videoMemoryBackupDirty = TRUE;
@@ -725,7 +725,7 @@ struct MyDirect3DTexture8
     static HRESULT STDMETHODCALLTYPE MySetPrivateData(IDirect3DTexture8* pThis, REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags)
 	{
 		HRESULT hr = SetPrivateData(pThis,refguid,pData,SizeOfData,Flags);
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 
 		IDirect3DTexture8_CustomData& tex8 = texture8data[pThis];
 		tex8.dirty = true;
@@ -737,7 +737,7 @@ struct MyDirect3DTexture8
     static HRESULT STDMETHODCALLTYPE MyFreePrivateData(IDirect3DTexture8* pThis, REFGUID refguid)
 	{
 		HRESULT hr = FreePrivateData(pThis,refguid);
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+        D3D_ENTER(pThis);
 
 		IDirect3DTexture8_CustomData& tex8 = texture8data[pThis];
 		tex8.dirty = false;
@@ -750,7 +750,7 @@ struct MyDirect3DTexture8
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DTexture8* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DTexture8* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		D3D_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -760,7 +760,7 @@ struct MyDirect3DTexture8
 	static HRESULT(STDMETHODCALLTYPE *UnlockRect)(IDirect3DTexture8* pThis, UINT Level);
 	static HRESULT STDMETHODCALLTYPE MyUnlockRect(IDirect3DTexture8* pThis, UINT Level)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+        D3D_ENTER(pThis);
 		HRESULT rv = UnlockRect(pThis, Level);
 		IDirect3DTexture8_CustomData& tex8 = texture8data[pThis];
 		tex8.dirty = true;
@@ -976,7 +976,7 @@ struct MyDirect3D8
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3D8* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3D8* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -986,7 +986,7 @@ struct MyDirect3D8
 	static HRESULT(STDMETHODCALLTYPE *CreateDevice)(IDirect3D8* pThis, UINT Adapter,D3DDEVTYPE DeviceType,HWND hFocusWindow,DWORD BehaviorFlags,D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DDevice8** ppReturnedDeviceInterface);
 	static HRESULT STDMETHODCALLTYPE MyCreateDevice(IDirect3D8* pThis, UINT Adapter,D3DDEVTYPE DeviceType,HWND hFocusWindow,DWORD BehaviorFlags,D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DDevice8** ppReturnedDeviceInterface)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams8(pPresentationParameters, pThis, NULL);
 		HRESULT rv = CreateDevice(pThis, Adapter,DeviceType,hFocusWindow,BehaviorFlags,pPresentationParameters,ppReturnedDeviceInterface);
 		if(SUCCEEDED(rv))

--- a/wintasee/hooks/d3d9hooks.cpp
+++ b/wintasee/hooks/d3d9hooks.cpp
@@ -132,7 +132,7 @@ struct MyDirect3DDevice9
 	static ULONG(STDMETHODCALLTYPE *Release)(IDirect3DDevice9* pThis);
 	static ULONG STDMETHODCALLTYPE MyRelease(IDirect3DDevice9* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		ULONG rv = Release(pThis);
 		if(rv == 0)
 		{
@@ -145,7 +145,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DDevice9* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DDevice9* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -155,7 +155,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *Reset)(IDirect3DDevice9* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters);
 	static HRESULT STDMETHODCALLTYPE MyReset(IDirect3DDevice9* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams9(pPresentationParameters, NULL, pThis);
 		d3d9BackBufActive = true;
 		d3d9BackBufDirty = true;
@@ -230,7 +230,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *Present)(IDirect3DDevice9* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion);
 	static HRESULT STDMETHODCALLTYPE MyPresent(IDirect3DDevice9* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 
 		HRESULT rv;
 		if(ShouldSkipDrawing(d3d9BackBufDirty, !d3d9BackBufDirty))
@@ -261,7 +261,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *GetSwapChain)(IDirect3DDevice9* pThis, UINT iSwapChain,IDirect3DSwapChain9** pSwapChain);
 	static HRESULT STDMETHODCALLTYPE MyGetSwapChain(IDirect3DDevice9* pThis, UINT iSwapChain,IDirect3DSwapChain9** pSwapChain)
 	{
-		d3ddebugprintf(__FUNCTION__ "(%d) called.\n", iSwapChain);
+		D3D_ENTER(iSwapChain);
 		HRESULT rv = GetSwapChain(pThis, iSwapChain, pSwapChain);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(IID_IDirect3DSwapChain9, (LPVOID*)pSwapChain);
@@ -271,7 +271,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *CreateAdditionalSwapChain)(IDirect3DDevice9* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DSwapChain9** pSwapChain);
 	static HRESULT STDMETHODCALLTYPE MyCreateAdditionalSwapChain(IDirect3DDevice9* pThis, D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DSwapChain9** pSwapChain)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams9(pPresentationParameters, NULL, pThis);
 		HRESULT rv = CreateAdditionalSwapChain(pThis, pPresentationParameters, pSwapChain);
 		if(SUCCEEDED(rv))
@@ -288,7 +288,7 @@ struct MyDirect3DDevice9
 	static HRESULT(STDMETHODCALLTYPE *SetRenderTarget)(IDirect3DDevice9* pThis, DWORD RenderTargetIndex, IDirect3DSurface9* pRenderTarget);
 	static HRESULT STDMETHODCALLTYPE MySetRenderTarget(IDirect3DDevice9* pThis, DWORD RenderTargetIndex, IDirect3DSurface9* pRenderTarget)
 	{
-		d3ddebugprintf(__FUNCTION__ "(%d) called.\n", RenderTargetIndex);
+		D3D_ENTER(RenderTargetIndex);
 		HRESULT rv = SetRenderTarget(pThis, RenderTargetIndex, pRenderTarget);
 		IDirect3DSurface9* pBackBuffer;
 		if(SUCCEEDED(pThis->GetBackBuffer(0,0,D3DBACKBUFFER_TYPE_MONO,&pBackBuffer)))
@@ -307,7 +307,7 @@ struct MyDirect3DDevice9
 
 	static void Lock(IDirect3DDevice9* pThis, DDSURFACEDESC& desc, IDirect3DSurface9*& pBackBuffer, bool getBackBuffer=true)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(getBackBuffer)
 			pThis->GetBackBuffer(0,0,D3DBACKBUFFER_TYPE_MONO,&pBackBuffer);
 
@@ -357,7 +357,7 @@ struct MyDirect3DDevice9
     static HRESULT(STDMETHODCALLTYPE *Clear)(IDirect3DDevice9* pThis, DWORD Count,CONST D3DRECT* pRects,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil);
     static HRESULT STDMETHODCALLTYPE MyClear(IDirect3DDevice9* pThis, DWORD Count,CONST D3DRECT* pRects,DWORD Flags,D3DCOLOR Color,float Z,DWORD Stencil)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = Clear(pThis, Count,pRects,Flags,Color,Z,Stencil);
@@ -369,7 +369,7 @@ struct MyDirect3DDevice9
     static HRESULT(STDMETHODCALLTYPE *DrawPrimitive)(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT StartVertex,UINT PrimitiveCount);
     static HRESULT STDMETHODCALLTYPE MyDrawPrimitive(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT StartVertex,UINT PrimitiveCount)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawPrimitive(pThis, PrimitiveType,StartVertex,PrimitiveCount);
@@ -381,7 +381,7 @@ struct MyDirect3DDevice9
     static HRESULT(STDMETHODCALLTYPE *DrawIndexedPrimitive)(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE primitiveType,INT baseVertexIndex,UINT minIndex,UINT NumVertices,UINT startIndex,UINT primCount);
     static HRESULT STDMETHODCALLTYPE MyDrawIndexedPrimitive(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE primitiveType,INT baseVertexIndex,UINT minIndex,UINT NumVertices,UINT startIndex,UINT primCount)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawIndexedPrimitive(pThis, primitiveType,baseVertexIndex,minIndex,NumVertices,startIndex,primCount);
@@ -393,7 +393,7 @@ struct MyDirect3DDevice9
     static HRESULT(STDMETHODCALLTYPE *DrawPrimitiveUP)(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT PrimitiveCount,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride);
     static HRESULT STDMETHODCALLTYPE MyDrawPrimitiveUP(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT PrimitiveCount,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawPrimitiveUP(pThis, PrimitiveType,PrimitiveCount,pVertexStreamZeroData,VertexStreamZeroStride);
@@ -405,7 +405,7 @@ struct MyDirect3DDevice9
     static HRESULT(STDMETHODCALLTYPE *DrawIndexedPrimitiveUP)(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT MinVertexIndex,UINT NumVertexIndices,UINT PrimitiveCount,CONST void* pIndexData,D3DFORMAT IndexDataFormat,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride);
     static HRESULT STDMETHODCALLTYPE MyDrawIndexedPrimitiveUP(IDirect3DDevice9* pThis, D3DPRIMITIVETYPE PrimitiveType,UINT MinVertexIndex,UINT NumVertexIndices,UINT PrimitiveCount,CONST void* pIndexData,D3DFORMAT IndexDataFormat,CONST void* pVertexStreamZeroData,UINT VertexStreamZeroStride)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		if(ShouldSkipDrawing(false, true))
 			return D3D_OK;
 		HRESULT rv = DrawIndexedPrimitiveUP(pThis, PrimitiveType,MinVertexIndex,NumVertexIndices,PrimitiveCount,pIndexData,IndexDataFormat,pVertexStreamZeroData,VertexStreamZeroStride);
@@ -459,7 +459,7 @@ struct MyDirect3DDevice9
 	//static HRESULT(STDMETHODCALLTYPE *CreateImageSurface)(IDirect3DDevice9* pThis, UINT Width,UINT Height,D3DFORMAT Format,IDirect3DSurface9** ppSurface);
 	//static HRESULT STDMETHODCALLTYPE MyCreateImageSurface(IDirect3DDevice9* pThis, UINT Width,UINT Height,D3DFORMAT Format,IDirect3DSurface9** ppSurface)
 	//{
-	//	d3ddebugprintf(__FUNCTION__ " called.\n");
+	//	D3D_ENTER();
 	//	HRESULT rv = CreateImageSurface(pThis,Width,Height,Format,ppSurface);
 	//	return rv;
 	//}
@@ -501,7 +501,7 @@ struct MyDirect3DSwapChain9
 	static ULONG(STDMETHODCALLTYPE *Release)(IDirect3DSwapChain9* pThis);
 	static ULONG STDMETHODCALLTYPE MyRelease(IDirect3DSwapChain9* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		ULONG rv = Release(pThis);
 		if(rv == 0)
 		{
@@ -513,7 +513,7 @@ struct MyDirect3DSwapChain9
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DSwapChain9* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DSwapChain9* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -523,7 +523,7 @@ struct MyDirect3DSwapChain9
 	static HRESULT(STDMETHODCALLTYPE *Present)(IDirect3DSwapChain9* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion,DWORD dwFlags);
 	static HRESULT STDMETHODCALLTYPE MyPresent(IDirect3DSwapChain9* pThis, CONST RECT* pSourceRect,CONST RECT* pDestRect,HWND hDestWindowOverride,CONST RGNDATA* pDirtyRegion,DWORD dwFlags)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 
 		HRESULT rv;
 		if(ShouldSkipDrawing(true, false))
@@ -634,7 +634,7 @@ struct MyDirect3DSurface9
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DSurface9* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DSurface9* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		D3D_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -644,7 +644,7 @@ struct MyDirect3DSurface9
 	static HRESULT(STDMETHODCALLTYPE *UnlockRect)(IDirect3DSurface9* pThis);
 	static HRESULT STDMETHODCALLTYPE MyUnlockRect(IDirect3DSurface9* pThis)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		HRESULT rv = UnlockRect(pThis);
 		IDirect3DSurface9_CustomData& surf9 = surface9data[pThis];
 		surf9.videoMemoryBackupDirty = TRUE;
@@ -707,7 +707,7 @@ struct MyDirect3DTexture9
     static HRESULT STDMETHODCALLTYPE MySetPrivateData(IDirect3DTexture9* pThis, REFGUID refguid,CONST void* pData,DWORD SizeOfData,DWORD Flags)
 	{
 		HRESULT hr = SetPrivateData(pThis,refguid,pData,SizeOfData,Flags);
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 
 		IDirect3DTexture9_CustomData& tex9 = texture9data[pThis];
 		tex9.dirty = true;
@@ -719,7 +719,7 @@ struct MyDirect3DTexture9
     static HRESULT STDMETHODCALLTYPE MyFreePrivateData(IDirect3DTexture9* pThis, REFGUID refguid)
 	{
 		HRESULT hr = FreePrivateData(pThis,refguid);
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 
 		IDirect3DTexture9_CustomData& tex9 = texture9data[pThis];
 		tex9.dirty = false;
@@ -732,7 +732,7 @@ struct MyDirect3DTexture9
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3DTexture9* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3DTexture9* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		D3D_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -742,7 +742,7 @@ struct MyDirect3DTexture9
 	static HRESULT(STDMETHODCALLTYPE *UnlockRect)(IDirect3DTexture9* pThis, UINT Level);
 	static HRESULT STDMETHODCALLTYPE MyUnlockRect(IDirect3DTexture9* pThis, UINT Level)
 	{
-		d3ddebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		D3D_ENTER(pThis);
 		HRESULT rv = UnlockRect(pThis, Level);
 		IDirect3DTexture9_CustomData& tex9 = texture9data[pThis];
 		tex9.dirty = true;
@@ -970,7 +970,7 @@ struct MyDirect3D9
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirect3D9* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirect3D9* pThis, REFIID riid, void** ppvObj)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -980,7 +980,7 @@ struct MyDirect3D9
 	static HRESULT(STDMETHODCALLTYPE *CreateDevice)(IDirect3D9* pThis, UINT Adapter,D3DDEVTYPE DeviceType,HWND hFocusWindow,DWORD BehaviorFlags,D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DDevice9** ppReturnedDeviceInterface);
 	static HRESULT STDMETHODCALLTYPE MyCreateDevice(IDirect3D9* pThis, UINT Adapter,D3DDEVTYPE DeviceType,HWND hFocusWindow,DWORD BehaviorFlags,D3DPRESENT_PARAMETERS* pPresentationParameters,IDirect3DDevice9** ppReturnedDeviceInterface)
 	{
-		d3ddebugprintf(__FUNCTION__ " called.\n");
+		D3D_ENTER();
 		ProcessPresentationParams9(pPresentationParameters, pThis, NULL);
 		HRESULT rv = CreateDevice(pThis, Adapter,DeviceType,hFocusWindow,BehaviorFlags,pPresentationParameters,ppReturnedDeviceInterface);
 		if(SUCCEEDED(rv))

--- a/wintasee/hooks/ddrawhooks.cpp
+++ b/wintasee/hooks/ddrawhooks.cpp
@@ -218,7 +218,7 @@ struct MyDirectDrawSurface
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(DIRECTDRAWSURFACEN* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(DIRECTDRAWSURFACEN* pThis, REFIID riid, void** ppvObj)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		DDRAW_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 		{
@@ -312,7 +312,7 @@ struct MyDirectDrawSurface
 	static HRESULT(STDMETHODCALLTYPE *Blt)(DIRECTDRAWSURFACEN* pThis, LPRECT destRect,DIRECTDRAWSURFACEN* pSource, LPRECT srcRect,DWORD flags, LPDDBLTFX bltfx);
 	static HRESULT STDMETHODCALLTYPE MyBlt(DIRECTDRAWSURFACEN* pThis, LPRECT destRect,DIRECTDRAWSURFACEN* pSource, LPRECT srcRect,DWORD flags, LPDDBLTFX bltfx)
 	{
-		ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		DDRAW_ENTER(pThis);
 		//cmdprintf("SHORTTRACE: 3,50");
 
 
@@ -474,15 +474,13 @@ struct MyDirectDrawSurface
 	static HRESULT(STDMETHODCALLTYPE *BltFast)(DIRECTDRAWSURFACEN* pThis, DWORD xDest,DWORD yDest,DIRECTDRAWSURFACEN* pSource, LPRECT srcRect,DWORD flags);
 	static HRESULT STDMETHODCALLTYPE MyBltFast(DIRECTDRAWSURFACEN* pThis, DWORD xDest,DWORD yDest,DIRECTDRAWSURFACEN* pSource, LPRECT srcRect,DWORD flags)
 	{
-		ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		DDRAW_ENTER(pThis);
 
 		// FIXME: probably doesn't handle forced windowed mode correctly (as regular Blt does)
 		// I don't know of any games that use it to draw to the fullscreen mode front buffer, though.
 
 		flags |= DDBLTFAST_WAIT;
 		flags &= ~DDBLTFAST_DONOTWAIT;
-
-		//ddrawdebugprintf(__FUNCTION__ " called.\n");
 
 		DDSCAPSN caps;
 		GetCaps(pThis, &caps);
@@ -586,7 +584,7 @@ struct MyDirectDrawSurface
 	static HRESULT STDMETHODCALLTYPE MyBltBatch(DIRECTDRAWSURFACEN* pThis, LPDDBLTBATCH a, DWORD b, DWORD c)
 	{
 		// NYI... do any games use this?
-		ddrawdebugprintf(__FUNCTION__ "(0x%X, 0x%X, 0x%X, 0x%X) called.\n", pThis, a, b, c);
+		DDRAW_ENTER(pThis, a, b, c);
 		HRESULT rv = BltBatch(pThis, a, b, c);
 		return rv;
 	}
@@ -596,7 +594,7 @@ struct MyDirectDrawSurface
 	{
 		HRESULT rv = GetCaps(pThis, lpddscaps);
 
-		ddrawdebugprintf(__FUNCTION__ " called. dwCaps = 0x%X.\n", lpddscaps->dwCaps);
+        DDRAW_ENTER(lpddscaps->dwCaps);
 
 		return rv;
 	}
@@ -606,7 +604,7 @@ struct MyDirectDrawSurface
 	{
 		HRESULT rv = GetSurfaceDesc(pThis, lpddsdesc);
 
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		DDSURFACEDESCN& ddsd = *lpddsdesc;
 		ddrawdebugprintf("dwFlags = 0x%X.\n", ddsd.dwFlags);
 		ddrawdebugprintf("dwWidth,dwHeight = %d,%d.\n", ddsd.dwWidth,ddsd.dwHeight);
@@ -660,7 +658,7 @@ struct MyDirectDrawSurface
 //#pragma message("FIXMEEE")
 //		cmdprintf("DEBUGREDALERT: 0");
 
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		if(lpddpfmt)
 			ddrawdebugprintf("dwRGBBitCount = %d.\n", lpddpfmt->dwRGBBitCount);
 
@@ -670,7 +668,7 @@ struct MyDirectDrawSurface
 	static HRESULT(STDMETHODCALLTYPE *Flip)(DIRECTDRAWSURFACEN* pThis, DIRECTDRAWSURFACEN* pOther, DWORD flags);
 	static HRESULT STDMETHODCALLTYPE MyFlip(DIRECTDRAWSURFACEN* pThis, DIRECTDRAWSURFACEN* pOther, DWORD flags)
 	{
-		ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+		DDRAW_ENTER(pThis);
 
 		HRESULT rv;
 		if(!(tasflags.forceWindowed))
@@ -710,7 +708,7 @@ struct MyDirectDrawSurface
 		GetCaps(pThis, &caps);
 		BOOL isPrimary = (caps.dwCaps & (DDSCAPS_PRIMARYSURFACE|DDSCAPS_FRONTBUFFER));
 
-		ddrawdebugprintf(__FUNCTION__ "(0x%X, lockFlags=0x%X, primary=%d) called.\n", pThis, lockFlags, isPrimary);
+		DDRAW_ENTER(pThis, lockFlags, isPrimary);
 
 		lockFlags |= DDLOCK_WAIT;
 
@@ -762,7 +760,7 @@ struct MyDirectDrawSurface
 		GetCaps(pThis, &caps);
 		BOOL isPrimary = (caps.dwCaps & (DDSCAPS_PRIMARYSURFACE|DDSCAPS_FRONTBUFFER));
 
-		ddrawdebugprintf(__FUNCTION__ "(0x%X, primary=%d) called.\n", pThis, isPrimary);
+		DDRAW_ENTER(pThis, isPrimary);
 
 		if(!isPrimary || IDirectDrawSurfaceTraits<IDirectDrawSurfaceN>::NUMBER > 3) // hack
 		{
@@ -848,7 +846,7 @@ struct MyDirectDrawSurface
 	static HRESULT(STDMETHODCALLTYPE *ReleaseDC)(DIRECTDRAWSURFACEN* pThis, HDC hdc);
 	static HRESULT STDMETHODCALLTYPE MyReleaseDC(DIRECTDRAWSURFACEN* pThis, HDC hdc)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		std::map<HDC,ManualHDCInfo>::iterator found = manuallyCreatedSurfaceDCs.find(hdc);
 		if(found == manuallyCreatedSurfaceDCs.end())
 		{
@@ -1036,7 +1034,7 @@ struct MyDirectDrawSurface
 					memcpy(pixels, desc.lpSurface, size);
 					Unlock(pThis, NULL);
 					ddrawdebugprintf("videoMemoryPixelBackup[0x%X] is 0x%X, size=0x%X\n", pThis, pixels, size);
-					// ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+					// DDRAW_ENTER(pThis);
 				}
 			}
 		}
@@ -1063,7 +1061,7 @@ struct MyDirectDrawSurface
 							memcpy(desc.lpSurface, pixels, size);
 							Unlock(pThis, NULL);
 							ddrawdebugprintf("videoMemoryPixelBackup[0x%X] is 0x%X, size=0x%X (restoring)\n", pThis, pixels, size);
-							// ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", pThis);
+							// DDRAW_ENTER(pThis);
 						}
 					}
 					else
@@ -1243,7 +1241,7 @@ public:
 	/*** IUnknown methods ***/
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 	{
-		ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+		DDRAW_ENTER(riid.Data1);
 		HRESULT rv = m_dd->QueryInterface(riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -1252,13 +1250,13 @@ public:
 
     ULONG STDMETHODCALLTYPE AddRef()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->AddRef();
 	}
 
     ULONG STDMETHODCALLTYPE Release()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		ULONG count = m_dd->Release();
 		if(0 == count)
 			delete this;
@@ -1269,12 +1267,12 @@ public:
     /*** IDirectDraw methods ***/
     STDMETHOD(Compact)()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->Compact();
 	}
     STDMETHOD(CreateClipper)(DWORD a, LPDIRECTDRAWCLIPPER FAR* b, IUnknown FAR * c)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->CreateClipper(a,b,c);
 	}
     STDMETHOD(CreatePalette)(DWORD dwFlags, LPPALETTEENTRY b, LPDIRECTDRAWPALETTE FAR* c, IUnknown FAR * d)
@@ -1330,7 +1328,7 @@ public:
 			//}
 		}
 
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		ddrawdebugprintf("dwFlags = 0x%X.\n", ddsd.dwFlags);
 		ddrawdebugprintf("dwWidth,dwHeight = %d,%d.\n", ddsd.dwWidth,ddsd.dwHeight);
 		ddrawdebugprintf("lPitch = %d.\n", ddsd.lPitch);
@@ -1473,7 +1471,7 @@ public:
 	}
     STDMETHOD(DuplicateSurface)( DIRECTDRAWSURFACEN* a, DIRECTDRAWSURFACEN* FAR * b)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		HRESULT rv = m_dd->DuplicateSurface(a,b);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(IID_IDirectDrawSurfaceN, (LPVOID*)b);
@@ -1481,27 +1479,27 @@ public:
 	}
     STDMETHOD(EnumDisplayModes)( DWORD a, DDSURFACEDESCN* b, LPVOID c, LPDDENUMMODESCALLBACKN d)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->EnumDisplayModes(a,b,c,d);
 	}
     STDMETHOD(EnumSurfaces)(DWORD a, DDSURFACEDESCN* b, LPVOID c,LPDDENUMSURFACESCALLBACKN d)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->EnumSurfaces(a,b,c,d);
 	}
     STDMETHOD(FlipToGDISurface)()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->FlipToGDISurface();
 	}
     STDMETHOD(GetCaps)( LPDDCAPS a, LPDDCAPS b)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->GetCaps(a,b);
 	}
     STDMETHOD(GetDisplayMode)( DDSURFACEDESCN* lpddsd)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		HRESULT rv = m_dd->GetDisplayMode(lpddsd);
 		if(SUCCEEDED(rv) && fakeDisplayValid)
 		{
@@ -1514,17 +1512,17 @@ public:
 	}
     STDMETHOD(GetFourCCCodes)( LPDWORD a, LPDWORD b)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->GetFourCCCodes(a,b);
 	}
     STDMETHOD(GetGDISurface)(DIRECTDRAWSURFACEN* FAR * a)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->GetGDISurface(a);
 	}
     STDMETHOD(GetMonitorFrequency)(LPDWORD a)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 //		return m_dd->GetMonitorFrequency(a);
 		if(fakeDisplayRefresh >= 10 && fakeDisplayRefresh <= 300)
 			return fakeDisplayRefresh;
@@ -1561,19 +1559,20 @@ public:
 	}
     STDMETHOD(Initialize)(GUID FAR * a)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->Initialize(a);
 	}
     STDMETHOD(RestoreDisplayMode)()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->RestoreDisplayMode();
 	}
     STDMETHOD(SetCooperativeLevel)(HWND hwnd, DWORD flags)
-	{
+    {
+        DDRAW_ENTER(hwnd, flags);
+
 		if(IsWindow(hwnd))
 			gamehwnd = hwnd;
-		ddrawdebugprintf(__FUNCTION__ "(0x%X, 0x%X) called.\n", hwnd, flags);
 
 		if(tasflags.forceWindowed)
 		{
@@ -1634,36 +1633,36 @@ public:
 	{
 //		if(tasflags.fastForward)
 			return DD_OK;
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->WaitForVerticalBlank(a,b);
 	}
 	
 	// IDirectDraw2
 	STDMETHOD(GetAvailableVidMem)(DDSCAPSN* a, LPDWORD b, LPDWORD c)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->GetAvailableVidMem(a,b,c);
 	}
 
 	// IDirectDraw4
 	STDMETHOD(GetSurfaceFromDC) (HDC a, DIRECTDRAWSURFACEN* * b)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->GetSurfaceFromDC(a,b);
 	}
     STDMETHOD(RestoreAllSurfaces)()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->RestoreAllSurfaces();
 	}
     STDMETHOD(TestCooperativeLevel)()
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		return m_dd->TestCooperativeLevel();
 	}
     STDMETHOD(GetDeviceIdentifier)(DDDEVICEIDENTIFIERN* a, DWORD b)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 
 		ThreadLocalStuff& curtls = tls;
 
@@ -1743,14 +1742,14 @@ template<> HRESULT MyDirectDraw<IDirectDraw>::SetDisplayMode(DWORD width, DWORD 
 
 template<> HRESULT MyDirectDraw<IDirectDraw7>::StartModeTest(LPSIZE a, DWORD b, DWORD c)
 {
-	ddrawdebugprintf(__FUNCTION__ " called.\n");
+	DDRAW_ENTER();
 //	if(tasflags.forceWindowed)
 //		return DD_OK;
 	return m_dd->StartModeTest(a,b,c);
 }
 template<> HRESULT MyDirectDraw<IDirectDraw7>::EvaluateMode(DWORD a, DWORD* b)
 {
-	ddrawdebugprintf(__FUNCTION__ " called.\n");
+	DDRAW_ENTER();
 //	if(tasflags.forceWindowed)
 //		return DD_OK;
 	return m_dd->EvaluateMode(a,b);
@@ -1785,7 +1784,7 @@ struct MyDirectDrawGammaControl
     static HRESULT(STDMETHODCALLTYPE *GetGammaRamp)(IDirectDrawGammaControl* pThis, DWORD dwFlags, LPDDGAMMARAMP pRamp);
     static HRESULT STDMETHODCALLTYPE MyGetGammaRamp(IDirectDrawGammaControl* pThis, DWORD dwFlags, LPDDGAMMARAMP pRamp)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called.\n");
+		DDRAW_ENTER();
 		//HRESULT rv = GetGammaRamp(pThis, dwFlags, pRamp);
 		HRESULT rv;
 		if(pRamp)
@@ -1848,7 +1847,7 @@ struct MyDirectDrawGammaControl
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirectDrawGammaControl* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirectDrawGammaControl* pThis, REFIID riid, void** ppvObj)
 	{
-		ddrawdebugprintf(__FUNCTION__ " called (0x%X).\n", riid.Data1);
+		DDRAW_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);

--- a/wintasee/hooks/ddrawhooks.cpp
+++ b/wintasee/hooks/ddrawhooks.cpp
@@ -893,7 +893,7 @@ struct MyDirectDrawSurface
     static HRESULT(STDMETHODCALLTYPE *SetPalette)(DIRECTDRAWSURFACEN* pThis, LPDIRECTDRAWPALETTE pPalette);
     static HRESULT STDMETHODCALLTYPE MySetPalette(DIRECTDRAWSURFACEN* pThis, LPDIRECTDRAWPALETTE pPalette)
 	{
-		debugprintf(__FUNCTION__ " called.\n");
+        ENTER();
 		HRESULT rv = SetPalette(pThis, pPalette);
 		if(tasflags.forceWindowed)
 		{

--- a/wintasee/hooks/gdihooks.cpp
+++ b/wintasee/hooks/gdihooks.cpp
@@ -615,10 +615,14 @@ HOOKFUNC HFONT WINAPI MyCreateFontIndirectW(CONST LOGFONTW *lplf)
 
 HOOKFUNC LONG WINAPI MyChangeDisplaySettingsA(LPDEVMODEA lpDevMode, DWORD dwFlags)
 {
-	if(lpDevMode)
-		debugprintf(__FUNCTION__ "(width=%d, height=%d, flags=0x%X) called.\n", lpDevMode->dmPelsWidth, lpDevMode->dmPelsHeight, dwFlags);
-	else
-		debugprintf(__FUNCTION__ "(flags=0x%X) called.\n", dwFlags);
+    if (lpDevMode)
+    {
+        ENTER(lpDevMode->dmPelsWidth, lpDevMode->dmPelsHeight, dwFlags);
+    }
+    else
+    {
+        ENTER(dwFlags);
+    }
 	if(tasflags.forceWindowed && lpDevMode /*&& (dwFlags & CDS_FULLSCREEN)*/)
 	{
 		fakeDisplayWidth = lpDevMode->dmPelsWidth;
@@ -638,9 +642,9 @@ HOOKFUNC LONG WINAPI MyChangeDisplaySettingsA(LPDEVMODEA lpDevMode, DWORD dwFlag
 HOOKFUNC LONG WINAPI MyChangeDisplaySettingsW(LPDEVMODEW lpDevMode, DWORD dwFlags)
 {
 	if(lpDevMode)
-		debugprintf(__FUNCTION__ "(width=%d, height=%d, flags=0x%X) called.\n", lpDevMode->dmPelsWidth, lpDevMode->dmPelsHeight, dwFlags);
+		ENTER(lpDevMode->dmPelsWidth, lpDevMode->dmPelsHeight, dwFlags);
 	else
-		debugprintf(__FUNCTION__ "(flags=0x%X) called.\n", dwFlags);
+		ENTER(dwFlags);
 	if(tasflags.forceWindowed && lpDevMode /*&& (dwFlags & CDS_FULLSCREEN)*/)
 	{
 		fakeDisplayWidth = lpDevMode->dmPelsWidth;

--- a/wintasee/hooks/inputhooks.cpp
+++ b/wintasee/hooks/inputhooks.cpp
@@ -8,21 +8,15 @@
 //#include "../tls.h"
 
 #if defined(_DEBUG) || 0//0
-	#define _DINPUTDEBUG
+    #define _DINPUTDEBUG
 #endif
 
 #if defined(_DINPUTDEBUG)
-	#define dinputdebugprintf debugprintf
-	#define DINPUT_ENTER ENTER
+    #define dinputdebugprintf debugprintf
+    #define DINPUT_ENTER ENTER
 #else
-	#if _MSC_VER > 1310
-		#define dinputdebugprintf(...) ((void)0)
-		#define DINPUT_ENTER(...) ((void)0)
-	#else
-		#define dinputdebugprintf() ((void)0)
-		#define DINPUT_ENTER(...) ((void)0)
-        #pragma warning(disable:4002)
-	#endif
+    #define dinputdebugprintf(...) ((void)0)
+    #define DINPUT_ENTER(...) ((void)0)
 #endif
 
 DEFINE_LOCAL_GUID(IID_IDirectInputDeviceA, 0x5944E680,0xC92E,0x11CF,0xBF,0xC7,0x44,0x45,0x53,0x54,0x00,0x00);

--- a/wintasee/hooks/inputhooks.cpp
+++ b/wintasee/hooks/inputhooks.cpp
@@ -13,12 +13,14 @@
 
 #if defined(_DINPUTDEBUG)
 	#define dinputdebugprintf debugprintf
+	#define DINPUT_ENTER ENTER
 #else
 	#if _MSC_VER > 1310
 		#define dinputdebugprintf(...) ((void)0)
+		#define DINPUT_ENTER(...) ((void)0)
 	#else
 		#define dinputdebugprintf() ((void)0)
-		#pragma warning(disable:4002)
+		#define DINPUT_ENTER(...) ((void)0)
 	#endif
 #endif
 
@@ -147,7 +149,7 @@ struct BufferedInput
 	}
 	HRESULT GetData(DWORD elemSize, LPDIDEVICEOBJECTDATA dataOut, LPDWORD numElements, DWORD flags)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//dinputdebugprintf(__FUNCTION__ " numElements=0x%X, dataOut=0x%X\n", numElements, dataOut);
 		if(!numElements)
 			return DIERR_INVALIDPARAM;
@@ -223,7 +225,7 @@ struct BufferedInput
 	}
 	void AddEvent(DIDEVICEOBJECTDATA inputEvent)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		if(used >= size)
 			overflowed = TRUE;
 		else
@@ -247,13 +249,13 @@ struct BufferedInput
 	}
 	static void AddEventToAllDevices(DIDEVICEOBJECTDATA inputEvent, BufferedInputList& bufferList)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		for(int i = (int)bufferList.size()-1; i >= 0; i--)
 			bufferList[i]->AddEvent(inputEvent);
 	}
 	void AddMouseEvent(DIDEVICEOBJECTDATA inputEvent)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		if(used >= size)
 			overflowed = TRUE;
 		else
@@ -268,7 +270,7 @@ struct BufferedInput
 	}
 	static void AddMouseEventToAllDevices(DIDEVICEOBJECTDATA inputEvent, BufferedInputList& bufferList)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		for(int i = (int)bufferList.size()-1; i >= 0; i--)
 			bufferList[i]->AddMouseEvent(inputEvent);
 	}
@@ -307,7 +309,7 @@ public:
 	/*** IUnknown methods ***/
 	STDMETHOD(QueryInterface)(REFIID riid, void** ppvObj)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		HRESULT rv = m_device->QueryInterface(riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -333,7 +335,7 @@ public:
 	/*** IDirectInputDevice methods ***/
 	STDMETHOD(GetCapabilities)(LPDIDEVCAPS lpDIDevCaps)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		if(m_type == GUID_SysMouse)
 		{
 			// This function requires that lpDIDevCaps exists and that it's dwSize member is initialized to either
@@ -435,7 +437,7 @@ public:
 
 	STDMETHOD(GetProperty)(REFGUID rguid, LPDIPROPHEADER ph)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->GetProperty(rguid, ph));
 		if(&rguid == &DIPROP_BUFFERSIZE)
 		{
@@ -451,7 +453,7 @@ public:
 
 	STDMETHOD(SetProperty)(REFGUID rguid, LPCDIPROPHEADER ph)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->SetProperty(rguid, ph);
 		if(&rguid == &DIPROP_BUFFERSIZE)
 		{
@@ -469,7 +471,7 @@ public:
 
 	STDMETHOD(Acquire)()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->Acquire();
 		if(m_acquired)
 			return DI_NOEFFECT;
@@ -479,7 +481,7 @@ public:
 
 	STDMETHOD(Unacquire)()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->Unacquire();
 		if(!m_acquired)
 			return DI_NOEFFECT;
@@ -489,7 +491,7 @@ public:
 
 	STDMETHOD(GetDeviceState)(DWORD size, LPVOID data)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->GetDeviceState(size, data));
 
 		if(!m_acquired)
@@ -566,7 +568,7 @@ public:
 
 	STDMETHOD(GetDeviceData)(DWORD size, LPDIDEVICEOBJECTDATA data, LPDWORD numElements, DWORD flags)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->GetDeviceData(size, data, numElements, flags);
 		if(!m_acquired)
 			return DIERR_NOTACQUIRED;
@@ -579,7 +581,7 @@ public:
 
 	STDMETHOD(SetDataFormat)(LPCDIDATAFORMAT lpdf)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->SetDataFormat(df));
 		
 		//debugprintf("df = 0x%X\n", df); // can't get at c_dfDIKeyboard... so do it at a lower level
@@ -603,7 +605,7 @@ public:
 
 	STDMETHOD(SetEventNotification)(HANDLE event)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->SetEventNotification(event));
 		if(m_acquired)
 			return DIERR_ACQUIRED;
@@ -613,7 +615,7 @@ public:
 
 	STDMETHOD(SetCooperativeLevel)(HWND window, DWORD level)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		if(IsWindow(window))
 			gamehwnd = window;
 		if(m_type == GUID_SysMouse){
@@ -753,21 +755,21 @@ public:
 
 	STDMETHOD(GetDeviceInfo)(LPDIDEVICEINSTANCEN di)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->GetDeviceInfo(di));
 		return DIERR_INVALIDPARAM; // NYI!
 	}
 
 	STDMETHOD(RunControlPanel)(HWND owner, DWORD flags)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->RunControlPanel(owner, flags));
 		return DI_OK;
 	}
 
 	STDMETHOD(Initialize)(HINSTANCE instance, DWORD version, REFGUID rguid)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->Initialize(instance, version, rguid));
 		return DI_OK;
 	}
@@ -775,49 +777,49 @@ public:
 	// DirectInputDevice2 methods
     STDMETHOD(CreateEffect)(REFGUID a, LPCDIEFFECT b, LPDIRECTINPUTEFFECT * c, LPUNKNOWN d)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->CreateEffect(a,b,c,d);
 		return DIERR_DEVICEFULL;
 	}
     STDMETHOD(EnumEffects)(LPDIENUMEFFECTSCALLBACKN a, LPVOID b, DWORD c)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->EnumEffects(a,b,c);
 		return DI_OK;
 	}
     STDMETHOD(GetEffectInfo)(LPDIEFFECTINFON a, REFGUID b)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->GetEffectInfo(a,b);
 		return E_POINTER;
 	}
     STDMETHOD(GetForceFeedbackState)(LPDWORD a)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->GetForceFeedbackState(a);
 		return DIERR_UNSUPPORTED;
 	}
     STDMETHOD(SendForceFeedbackCommand)(DWORD a)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->SendForceFeedbackCommand(a);
 		return DIERR_UNSUPPORTED;
 	}
     STDMETHOD(EnumCreatedEffectObjects)(LPDIENUMCREATEDEFFECTOBJECTSCALLBACK a, LPVOID b, DWORD c)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->EnumCreatedEffectObjects(a,b,c);
 		return DI_OK;
 	}
     STDMETHOD(Escape)(LPDIEFFESCAPE a)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->Escape(a);
 		return DI_OK;
 	}
     STDMETHOD(Poll)()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->Poll());
 		if(!m_acquired)
 			return DIERR_NOTACQUIRED;
@@ -826,39 +828,39 @@ public:
 
 	STDMETHOD(SendDeviceData)(DWORD a, LPCDIDEVICEOBJECTDATA b, LPDWORD c, DWORD d)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return rvfilter(m_device->SendDeviceData(a,b,c,d));
 		return DI_OK; // according to the documentation, this function never does anything anyway and should not be called
 	}
 	// IDirectInputDevice7 methods
     STDMETHOD(EnumEffectsInFile)(LPCNSTR a, LPDIENUMEFFECTSINFILECALLBACK b, LPVOID c, DWORD d)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->EnumEffectsInFile(a,b,c,d);
 		return DI_OK;
 	}
     STDMETHOD(WriteEffectToFile)(LPCNSTR a, DWORD b, LPDIFILEEFFECT c, DWORD d)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->WriteEffectToFile(a,b,c,d);
 		return DIERR_INVALIDPARAM; // more like DIERR_NYI
 	}
 	// IDirectInputDevice8 methods
     STDMETHOD(BuildActionMap)(LPDIACTIONFORMATN a, LPCNSTR b, DWORD c)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->BuildActionMap(a,b,c);
 		return DIERR_MAPFILEFAIL; // more like DIERR_NYI
 	}
     STDMETHOD(SetActionMap)(LPDIACTIONFORMATN a, LPCNSTR b, DWORD c)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->SetActionMap(a,b,c);
 		return DIERR_INVALIDPARAM; // more like DIERR_NYI
 	}
     STDMETHOD(GetImageInfo)(LPDIDEVICEIMAGEINFOHEADERN a)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		//return m_device->GetImageInfo(a);
 		return DIERR_MAPFILEFAIL; // more like DIERR_NYI
 	}
@@ -963,17 +965,17 @@ public:
 
 	MyDirectInput(IDirectInputN* di) : m_di(di)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 	}
 	~MyDirectInput()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 	}
 
 	/*** IUnknown methods ***/
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		HRESULT rv = m_di->QueryInterface(riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -982,13 +984,13 @@ public:
 
     ULONG STDMETHODCALLTYPE AddRef()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->AddRef();
 	}
 
     ULONG STDMETHODCALLTYPE Release()
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		ULONG count = m_di->Release();
 		if(0 == count)
 			delete this;
@@ -999,7 +1001,7 @@ public:
     /*** IDirectInputN methods ***/
     STDMETHOD(CreateDevice)(REFGUID rguid, IDirectInputDeviceN** device, LPUNKNOWN unknown)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		ThreadLocalStuff& curtls = tls;
 		curtls.callerisuntrusted++;
 		HRESULT hr = m_di->CreateDevice(rguid, device, unknown);
@@ -1017,7 +1019,7 @@ public:
 
     STDMETHOD(EnumDevices)(DWORD devType,LPDIENUMDEVICESCALLBACKN callback, LPVOID ref, DWORD flags)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		// FIXME: NYI.
 		// this is leaking data to the game!
 		// for now, let's at least untrust it.
@@ -1030,19 +1032,19 @@ public:
 
     STDMETHOD(GetDeviceStatus)(REFGUID rguid)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->GetDeviceStatus(rguid);
 	}
 
     STDMETHOD(RunControlPanel)(HWND owner, DWORD flags)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->RunControlPanel(owner, flags);
 	}
 
     STDMETHOD(Initialize)(HINSTANCE instance, DWORD version)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->Initialize(instance, version);
 	}
 
@@ -1060,17 +1062,17 @@ public:
 
     STDMETHOD(FindDevice)(REFGUID a, LPCNSTR b, LPGUID c)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->FindDevice(a,b,c);
 	}
     STDMETHOD(EnumDevicesBySemantics)(LPCNSTR a, LPDIACTIONFORMATN b, LPDIENUMDEVICESBYSEMANTICSCBN c, LPVOID d, DWORD e)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->EnumDevicesBySemantics(a,b,c,d,e);
 	}
     STDMETHOD(ConfigureDevices)(LPDICONFIGUREDEVICESCALLBACK a, LPDICONFIGUREDEVICESPARAMSN b, DWORD c, LPVOID d)
 	{
-		dinputdebugprintf(__FUNCTION__ " called.\n");
+		DINPUT_ENTER();
 		return m_di->ConfigureDevices(a,b,c,d);
 	}
 

--- a/wintasee/hooks/inputhooks.cpp
+++ b/wintasee/hooks/inputhooks.cpp
@@ -131,7 +131,7 @@ struct BufferedInput
 	}
 	void Resize(DWORD newSize)
 	{
-		dinputdebugprintf(__FUNCTION__ "(%d) called.\n", newSize);
+        DINPUT_ENTER(newSize);
 		DWORD oldSize = size;
 		size = newSize;
 
@@ -150,12 +150,11 @@ struct BufferedInput
 	}
 	HRESULT GetData(DWORD elemSize, LPDIDEVICEOBJECTDATA dataOut, LPDWORD numElements, DWORD flags)
 	{
-		DINPUT_ENTER();
-		//dinputdebugprintf(__FUNCTION__ " numElements=0x%X, dataOut=0x%X\n", numElements, dataOut);
+		DINPUT_ENTER(elemSize, dataOut, numElements, flags);
 		if(!numElements)
 			return DIERR_INVALIDPARAM;
 
-		dinputdebugprintf(__FUNCTION__ " size=%d, used=%d, elemSize=%d, *numElements=%d, flags=%d\n", size,used,elemSize,*numElements,flags);
+		dinputdebugprintf(__FUNCTION__ " size=%d, used=%d, *numElements=%d\n", size, used, *numElements);
 
 		DWORD retrieved = 0;
 		DWORD requested = *numElements;
@@ -364,7 +363,7 @@ public:
 
 	STDMETHOD(EnumObjects)(LPDIENUMDEVICEOBJECTSCALLBACKN lpCallback, LPVOID pvRef, DWORD dwFlags)	
 	{
-		dinputdebugprintf(__FUNCTION__ " called with flags: 0x%X.\n", dwFlags);
+        DINPUT_ENTER(dwFlags);
 
 		if(m_type == GUID_SysMouse)
 		{
@@ -628,7 +627,7 @@ public:
 
 	STDMETHOD(GetObjectInfo)(LPDIDEVICEOBJECTINSTANCEN pdidoi, DWORD dwObj, DWORD dwHow)
 	{
-		dinputdebugprintf(__FUNCTION__ " called with dwObj %u and dwHow %u.\n", dwObj, dwHow);
+        DINPUT_ENTER(dwObj, dwHow);
 		if(m_type == GUID_SysMouse)
 		{
 			// This function requires that pdidoi is created by the game, and has it's dwSize member inited to the size of the struct,
@@ -1051,7 +1050,7 @@ public:
 
 	STDMETHOD(CreateDeviceEx)(REFGUID a, REFIID b, LPVOID* c, LPUNKNOWN d)
 	{
-		dinputdebugprintf(__FUNCTION__ "(0x%X, 0x%X) called.\n", a.Data1, b.Data1);
+        DINPUT_ENTER(a.Data1, b.Data1);
 		ThreadLocalStuff& curtls = tls;
 		curtls.callerisuntrusted++;
 		HRESULT hr = m_di->CreateDeviceEx(a,b,c,d);

--- a/wintasee/hooks/inputhooks.cpp
+++ b/wintasee/hooks/inputhooks.cpp
@@ -21,6 +21,7 @@
 	#else
 		#define dinputdebugprintf() ((void)0)
 		#define DINPUT_ENTER(...) ((void)0)
+        #pragma warning(disable:4002)
 	#endif
 #endif
 

--- a/wintasee/hooks/messagehooks.cpp
+++ b/wintasee/hooks/messagehooks.cpp
@@ -762,7 +762,7 @@ HOOKFUNC LRESULT WINAPI MyCallNextHookEx(HHOOK hhk, int nCode, WPARAM wParam, LP
 
 //HOOKFUNC BOOL WINAPI MyRegisterUserApiHook(HINSTANCE hInst, FARPROC func)
 //{
-//	//debugprintf(__FUNCTION__ " called.\n");
+//	//ENTER();
 //	return 1;
 //}
 
@@ -1597,7 +1597,7 @@ HOOKFUNC LRESULT WINAPI MyDispatchMessageW(CONST MSG *lpMsg)
 
 HOOKFUNC BOOL WINAPI MyGetMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax)
 {
-//	verbosedebugprintf(__FUNCTION__"(0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+//	VERBOSE_ENTER(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
 	debuglog(LCF_MESSAGES|LCF_WAIT|LCF_FREQUENT, __FUNCTION__ "(0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
 #ifdef EMULATE_MESSAGE_QUEUES
 	if(!lpMsg)
@@ -1701,7 +1701,7 @@ HOOKFUNC BOOL WINAPI MyGetMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, U
 }
 HOOKFUNC BOOL WINAPI MyGetMessageW(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax)
 {
-//	verbosedebugprintf(__FUNCTION__"(0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
+//	VERBOSE_ENTER(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
 	debuglog(LCF_MESSAGES|LCF_WAIT|LCF_FREQUENT, __FUNCTION__ "(0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
 #ifdef EMULATE_MESSAGE_QUEUES
 	if(!lpMsg)
@@ -1802,7 +1802,7 @@ HOOKFUNC BOOL WINAPI MyGetMessageW(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, U
 }
 HOOKFUNC BOOL WINAPI MyPeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax, UINT wRemoveMsg)
 {
-//	verbosedebugprintf(__FUNCTION__"(0x%X, 0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
+//	VERBOSE_ENTER(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
 ////	FrameBoundary();
 	debuglog(LCF_MESSAGES|LCF_WAIT|LCF_FREQUENT, __FUNCTION__ "(0x%X, 0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
 	if(!lpMsg)
@@ -1895,7 +1895,7 @@ HOOKFUNC BOOL WINAPI MyPeekMessageA(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, 
 }
 HOOKFUNC BOOL WINAPI MyPeekMessageW(LPMSG lpMsg, HWND hWnd, UINT wMsgFilterMin, UINT wMsgFilterMax, UINT wRemoveMsg)
 {
-//	verbosedebugprintf(__FUNCTION__"(0x%X, 0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
+//	VERBOSE_ENTER(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
 	debuglog(LCF_MESSAGES|LCF_WAIT|LCF_FREQUENT, __FUNCTION__ "(0x%X, 0x%X, 0x%X, 0x%X, 0x%X) called.\n", lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
 	if(!lpMsg)
 		return FALSE;

--- a/wintasee/hooks/modulehooks.cpp
+++ b/wintasee/hooks/modulehooks.cpp
@@ -434,7 +434,7 @@ HOOKFUNC NTSTATUS NTAPI MyLdrLoadDll(PWCHAR PathToFile, ULONG Flags, PUNICODE_ST
 
 HOOKFUNC VOID NTAPI MyKiUserCallbackDispatcher(ULONG ApiNumber, PVOID InputBuffer, ULONG InputLength)
 {
-	//debugprintf(__FUNCTION__ "(ApiNumber=%d) called.\n",ApiNumber);
+	//ENTER(ApiNumber);
 
 	// maybe should instead scan the stack in MyLdrLoadDll for something we put on the stack in MyKiUserCallbackDispatcher? but I couldn't get it to work...
 //	char test [8] = {0,0x42,0x42,0x42,0x42,0x42,0x42,0x42,};

--- a/wintasee/hooks/soundhooks.cpp
+++ b/wintasee/hooks/soundhooks.cpp
@@ -508,7 +508,7 @@ public:
     // IDirectSoundBuffer8 methods
     STDMETHOD(SetFX)                (DWORD dwEffectsCount, LPDSEFFECTDESC pDSFXDesc, LPDWORD pdwResultCodes)
 	{
-		/*dsound*/debugprintf(__FUNCTION__ " called.\n");
+        /*dsound*/ENTER();
 		if(!(capsFlags & DSBCAPS_CTRLFX))
 			return DSERR_CONTROLUNAVAIL;
 		// NYI! chorus (GUID_DSFX_STANDARD_CHORUS), echo, flanger, gargle, distortion, etc.
@@ -518,13 +518,13 @@ public:
 	}
     STDMETHOD(AcquireResources)     (DWORD dwFlags, DWORD dwEffectsCount, LPDWORD pdwResultCodes)
 	{
-		/*dsound*/debugprintf(__FUNCTION__ " called.\n");
+        /*dsound*/ENTER();
 		// NYI
 		return DSERR_CONTROLUNAVAIL;
 	}
     STDMETHOD(GetObjectInPath)      (REFGUID rguidObject, DWORD dwIndex, REFGUID rguidInterface, LPVOID *ppObject)
 	{
-		/*dsound*/debugprintf(__FUNCTION__ " called.\n");
+        /*dsound*/ENTER();
 		// NYI
 		return DSERR_CONTROLUNAVAIL;
 	}
@@ -1086,7 +1086,7 @@ public:
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 	{
 		while(lockdown) Sleep(1); 
-		/*dsound*/debugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+		/*dsound*/ENTER(riid.Data1);
 		HRESULT rv = m_dsb->QueryInterface(riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -1844,7 +1844,7 @@ struct MyDirectMusicPerformance
     static HRESULT(STDMETHODCALLTYPE *Init)(IDirectMusicPerformanceN* pThis, IDirectMusic** ppDirectMusic, LPDIRECTSOUND pDirectSound, HWND hWnd);
     static HRESULT STDMETHODCALLTYPE MyInit(IDirectMusicPerformanceN* pThis, IDirectMusic** ppDirectMusic, LPDIRECTSOUND pDirectSound, HWND hWnd)
 	{
-		/*dmusic*/debugprintf(__FUNCTION__ " called.\n");
+        /*dmusic*/ENTER();
 		const char* oldName = tls.curThreadCreateName;
 		tls.curThreadCreateName = "DirectMusic";
 		HRESULT rv = Init(pThis, ppDirectMusic, pDirectSound, hWnd);
@@ -1857,7 +1857,8 @@ struct MyDirectMusicPerformance
     static HRESULT(STDMETHODCALLTYPE *InitAudio)(IDirectMusicPerformanceN* pThis, IDirectMusic** ppDirectMusic, IDirectSound** ppDirectSound, HWND hWnd, DWORD dwDefaultPathType, DWORD dwPChannelCount, DWORD dwFlags, DMUS_AUDIOPARAMS *pParams);
     static HRESULT STDMETHODCALLTYPE MyInitAudio(IDirectMusicPerformanceN* pThis, IDirectMusic** ppDirectMusic, IDirectSound** ppDirectSound, HWND hWnd, DWORD dwDefaultPathType, DWORD dwPChannelCount, DWORD dwFlags, DMUS_AUDIOPARAMS *pParams)
 	{
-		/*dmusic*/debugprintf(__FUNCTION__ "(ppDirectMusic=0x%X, ppDirectSound=0x%X, *pDirectSound=0x%X, dwFlags=0x%X, pParams=0x%X) called.\n", ppDirectMusic, ppDirectSound, ppDirectSound?*ppDirectSound:0, dwFlags, pParams);
+        auto pDirectSound = ppDirectSound ? *ppDirectSound : 0;
+		/*dmusic*/ENTER(ppDirectMusic, ppDirectSound, pDirectSound, dwFlags, pParams);
 		const char* oldName = tls.curThreadCreateName;
 		tls.curThreadCreateName = "DirectMusic";
 		HRESULT rv = InitAudio(pThis, ppDirectMusic, ppDirectSound, hWnd, dwDefaultPathType, dwPChannelCount, dwFlags, pParams);

--- a/wintasee/hooks/soundhooks.cpp
+++ b/wintasee/hooks/soundhooks.cpp
@@ -534,7 +534,7 @@ public:
     // IDirectSoundNotify methods
     STDMETHOD(SetNotificationPositions) (DWORD dwPositionNotifies, LPCDSBPOSITIONNOTIFY pcPositionNotifies)
 	{
-		dsounddebugprintf(__FUNCTION__ "(%d) called.\n", dwPositionNotifies);
+		DSOUND_ENTER(dwPositionNotifies);
 		if(dwPositionNotifies > DSBNOTIFICATIONS_MAX || pcPositionNotifies == NULL)
 			return DSERR_INVALIDPARAM;
 
@@ -1459,7 +1459,7 @@ public:
 	/*** IUnknown methods ***/
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 	{
-		dsounddebugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+		DSOUND_ENTER(riid.Data1);
 		if(ppvObj)
 		{
 			if(riid == IID_IUnknown) { *ppvObj = (IUnknown*)this; AddRef(); return S_OK; }
@@ -1834,7 +1834,7 @@ struct MyDirectMusicPerformance
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirectMusicPerformanceN* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirectMusicPerformanceN* pThis, REFIID riid, void** ppvObj)
 	{
-		dmusicdebugprintf(__FUNCTION__ " called.\n");
+        DMUSIC_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -1902,7 +1902,7 @@ struct MyDirectMusic
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirectMusicN* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirectMusicN* pThis, REFIID riid, void** ppvObj)
 	{
-		dmusicdebugprintf(__FUNCTION__ " called.\n");
+        DMUSIC_ENTER();
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -1921,7 +1921,7 @@ struct MyDirectMusic
 	static HRESULT(STDMETHODCALLTYPE *SetMasterClock)(IDirectMusicN* pThis, REFGUID rguidClock);
 	static HRESULT STDMETHODCALLTYPE MySetMasterClock(IDirectMusicN* pThis, REFGUID rguidClock)
 	{
-		dmusicdebugprintf(__FUNCTION__ " called.\n");
+		DMUSIC_ENTER();
 		return DMUS_E_PORTS_OPEN; // disallow changing the clock
 	}
 
@@ -1982,7 +1982,7 @@ struct MyMediaFilter
 	static HRESULT(STDMETHODCALLTYPE *SetSyncSource)             (IMediaFilter* pThis, IReferenceClock* pClock);
 	static HRESULT STDMETHODCALLTYPE MySetSyncSource             (IMediaFilter* pThis, IReferenceClock* pClock)
 	{
-		dmusicdebugprintf(__FUNCTION__ "(0x%X) called.\n", pClock);
+		DMUSIC_ENTER(pClock);
 		if(pClock)
 			HookCOMInterface(IID_IReferenceClock, (LPVOID*)&pClock);
 		HRESULT rv = MyMediaFilter::SetSyncSource(pThis, pClock);
@@ -2018,7 +2018,7 @@ struct MyBaseFilter
 //{
 //	static BOOL Hook(IUnknown* obj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", obj);
+//		ENTER(obj);
 //		cmdprintf("SHORTTRACE: 3,50");
 //		BOOL rv = FALSE;
 //		//for(int i = 0; i < 1000; i++)
@@ -2456,7 +2456,7 @@ public:
 //{
 //	static BOOL Hook(IDirectSoundSink* obj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", obj);
+//		ENTER(obj);
 //		BOOL rv = FALSE;
 //		rv |= HookVTable(obj, 0, (FARPROC)MyQueryInterface, (FARPROC&)QueryInterface, __FUNCTION__": QueryInterface");
 //		rv |= VTHOOKFUNC(IDirectSoundSink, GetSoundBufferBusIDs);
@@ -2467,7 +2467,7 @@ public:
 //	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirectSoundSink* pThis, REFIID riid, void** ppvObj);
 //	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirectSoundSink* pThis, REFIID riid, void** ppvObj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+//		ENTER(riid.Data1);
 //		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 //		if(SUCCEEDED(rv))
 //			HookCOMInterface(riid, ppvObj);
@@ -2501,7 +2501,7 @@ public:
 //{
 //	static BOOL Hook(IDirectSoundSinkFactory* obj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", obj);
+//		ENTER(obj);
 //		BOOL rv = FALSE;
 //		rv |= VTHOOKFUNC(IDirectSoundSinkFactory, CreateSoundSink);
 //		rv |= HookVTable(obj, 0, (FARPROC)MyQueryInterface, (FARPROC&)QueryInterface, __FUNCTION__": QueryInterface");
@@ -2511,7 +2511,7 @@ public:
 //	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IDirectSoundSinkFactory* pThis, REFIID riid, void** ppvObj);
 //	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IDirectSoundSinkFactory* pThis, REFIID riid, void** ppvObj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+//		ENTER(riid.Data1);
 //		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 //		if(SUCCEEDED(rv))
 //			HookCOMInterface(riid, ppvObj);

--- a/wintasee/hooks/timehooks.cpp
+++ b/wintasee/hooks/timehooks.cpp
@@ -50,17 +50,17 @@ DEFINE_LOCAL_GUID(IID_IReferenceClock,0x56a86897,0x0ad4,0x11ce,0xb0,0x3a,0x00,0x
 //{
 //	MyReferenceClock()
 //	{
-//		ddrawdebugprintf(__FUNCTION__ " called.\n");
+//		DDRAW_ENTER();
 //	}
 //	~MyReferenceClock()
 //	{
-//		ddrawdebugprintf(__FUNCTION__ " called.\n");
+//		DDRAW_ENTER();
 //	}
 //
 //	/*** IUnknown methods ***/
 //    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 //	{
-//		ddrawdebugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+//		DDRAW_ENTER(riid.Data1);
 //		HRESULT rv = m_dd->QueryInterface(riid, ppvObj);
 //		if(SUCCEEDED(rv))
 //			HookCOMInterface(riid, ppvObj);
@@ -69,13 +69,13 @@ DEFINE_LOCAL_GUID(IID_IReferenceClock,0x56a86897,0x0ad4,0x11ce,0xb0,0x3a,0x00,0x
 //
 //    ULONG STDMETHODCALLTYPE AddRef()
 //	{
-//		ddrawdebugprintf(__FUNCTION__ " called.\n");
+//		DDRAW_ENTER();
 //		return m_dd->AddRef();
 //	}
 //
 //    ULONG STDMETHODCALLTYPE Release()
 //	{
-//		ddrawdebugprintf(__FUNCTION__ " called.\n");
+//		DDRAW_ENTER();
 //		ULONG count = m_dd->Release();
 //		if(0 == count)
 //			delete this;
@@ -103,7 +103,7 @@ struct MyReferenceClock : IReferenceClock
 	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IReferenceClock* pThis, REFIID riid, void** ppvObj);
 	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IReferenceClock* pThis, REFIID riid, void** ppvObj)
 	{
-		verbosedebugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+		VERBOSE_ENTER(riid.Data1);
 		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -215,7 +215,7 @@ struct MyReferenceClock : IReferenceClock
 //	static HRESULT(STDMETHODCALLTYPE *QueryInterface)(IAMOpenProgress* pThis, REFIID riid, void** ppvObj);
 //	static HRESULT STDMETHODCALLTYPE MyQueryInterface(IAMOpenProgress* pThis, REFIID riid, void** ppvObj)
 //	{
-//		debugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+//		ENTER(riid.Data1);
 //		HRESULT rv = QueryInterface(pThis, riid, ppvObj);
 //		if(SUCCEEDED(rv))
 //			HookCOMInterface(riid, ppvObj);

--- a/wintasee/hooks/timerhooks.cpp
+++ b/wintasee/hooks/timerhooks.cpp
@@ -316,7 +316,7 @@ static int timerListSize = 0;
 // MULTI-THREADED APPROACH
 DWORD WINAPI MyTimerThread(LPVOID lpParam)
 {
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+	VERBOSE_ENTER();
 	TimerThreadInfo* info = (TimerThreadInfo*)lpParam;
 
 	int isSetEvent = info->event & TIME_CALLBACK_EVENT_SET;
@@ -383,7 +383,7 @@ HOOKFUNC MMRESULT WINAPI MytimeSetEvent(UINT uDelay, UINT uResolution,
 LPTIMECALLBACK lpTimeProc, DWORD_PTR dwUser, UINT fuEvent)
 {
 //	return timeSetEvent(uDelay, uResolution, lpTimeProc, dwUser, fuEvent);
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+	VERBOSE_ENTER();
 	TimerThreadInfo* threadInfo = new TimerThreadInfo(uDelay, uResolution, fuEvent, lpTimeProc, dwUser, 11 * ++timerUID);
 	threadInfo->prev = ttiTail;
 	ttiTail->next = threadInfo;
@@ -403,7 +403,7 @@ LPTIMECALLBACK lpTimeProc, DWORD_PTR dwUser, UINT fuEvent)
 HOOKFUNC MMRESULT WINAPI MytimeKillEvent(UINT uTimerID)
 {
 //	return timeKillEvent(uTimerID);
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+	VERBOSE_ENTER();
 
 	verbosedebugprintf(__FUNCTION__ "(0x%X)\n", uTimerID);
 	TimerThreadInfo* info = ttiHead;

--- a/wintasee/hooks/windowhooks.cpp
+++ b/wintasee/hooks/windowhooks.cpp
@@ -618,22 +618,22 @@ HOOKFUNC int WINAPI MyMessageBoxExW(HWND hWnd, LPCWSTR lpText, LPCWSTR lpCaption
 }
 HOOKFUNC INT_PTR WINAPI MyDialogBoxParamA(HINSTANCE hInstance,LPCSTR lpTemplateName,HWND hWndParent,DLGPROC lpDialogFunc,LPARAM dwInitParam)
 {
-	debugprintf(__FUNCTION__ " called.\n");
+    ENTER();
 	return IDOK;
 }
 HOOKFUNC INT_PTR WINAPI MyDialogBoxParamW(HINSTANCE hInstance,LPCWSTR lpTemplateName,HWND hWndParent,DLGPROC lpDialogFunc,LPARAM dwInitParam)
 {
-	debugprintf(__FUNCTION__ " called.\n");
+	ENTER();
 	return IDOK;
 }
 HOOKFUNC INT_PTR WINAPI MyDialogBoxIndirectParamA(HINSTANCE hInstance,LPCDLGTEMPLATEA hDialogTemplate,HWND hWndParent,DLGPROC lpDialogFunc,LPARAM dwInitParam)
 {
-	debugprintf(__FUNCTION__ " called.\n");
+	ENTER();
 	return IDOK;
 }
 HOOKFUNC INT_PTR WINAPI MyDialogBoxIndirectParamW(HINSTANCE hInstance,LPCDLGTEMPLATEW hDialogTemplate,HWND hWndParent,DLGPROC lpDialogFunc,LPARAM dwInitParam)
 {
-	debugprintf(__FUNCTION__ " called.\n");
+	ENTER();
 	return IDOK;
 }
 

--- a/wintasee/print.cpp
+++ b/wintasee/print.cpp
@@ -37,7 +37,7 @@ int debugprintf(const char* fmt, ...)
     }
 
     char str[4096];
-    str[ARRAYSIZE(str) - 1] = '\0';
+    memset(str, '\0', sizeof(str));
 
     int threadStamp = getCurrentThreadstamp();
     if (threadStamp)
@@ -63,7 +63,7 @@ int debugprintf(const char* fmt, ...)
 int cmdprintf(const char* fmt, ...)
 {
     char str[4096];
-    str[ARRAYSIZE(str) - 1] = '\0';
+    memset(str, '\0', sizeof(str));
 
     va_list args;
     va_start(args, fmt);
@@ -83,7 +83,7 @@ int logprintf_internal(LogCategoryFlag cat, const char* fmt, ...)
     }
 
     char str[4096];
-    str[ARRAYSIZE(str) - 1] = '\0';
+    memset(str, '\0', sizeof(str));
 
     int threadStamp = getCurrentThreadstamp();
     if (threadStamp)

--- a/wintasee/print.cpp
+++ b/wintasee/print.cpp
@@ -5,7 +5,7 @@
 #define PRINT_C_INCL
 
 #include <windows.h>
-#include <stdio.h>
+#include <cstdio>
 #include "print.h"
 #include "global.h"
 
@@ -29,32 +29,35 @@ extern int getCurrentTimestamp();
 TRAMPFUNC DWORD WINAPI TramptimeGetTime(void);
 
 #ifndef debugprintf
-int debugprintf(const char * fmt, ...)
+int debugprintf(const char* fmt, ...)
 {
-	//if(!notramps && GetAsyncKeyState('A') & 0x8000)
-	//	return 0;
-	if(tasflags.debugPrintMode == 0)
-		return 0;
-	char str[4096];
-	//str[sizeof(str)-1] = 0x61;
-	va_list args;
-	va_start (args, fmt);
-	strcpy(str, "MSG: ");
-	int threadStamp = getCurrentThreadstamp();
-	// TODO: passing in extra argument (notramps?0:TramptimeGetTime()) makes cave story run significantly faster in fast-forward, weird, but that's why I've left it here for now
-	if(threadStamp)
-		sprintf(str+(sizeof("MSG: ")-1), "%08X: (f=%d, t=%d) ", getCurrentThreadstamp(), getCurrentFramestamp(), getCurrentTimestamp(), notramps?0:TramptimeGetTime());
-	else
-		sprintf(str+(sizeof("MSG: ")-1), "MAIN: (f=%d, t=%d) ", getCurrentFramestamp(), getCurrentTimestamp(), notramps?0:TramptimeGetTime());
-	int headerlen = strlen(str);
-	//int rv = vsprintf (str+5+10, fmt, args);
-	int rv = vsprintf(str+headerlen, fmt, args);
-	va_end (args);
-	OutputDebugStringA(str);
-	//if(str[sizeof(str)-1] != 0x61) { _asm{int 3} } // buffer overrun alert
-	return rv;
+    if (tasflags.debugPrintMode == 0)
+    {
+        return 0;
+    }
+
+    char str[4096];
+    int threadStamp = getCurrentThreadstamp();
+    if (threadStamp)
+    {
+        sprintf(str, "MSG: %08X: (f=%d, t=%d) ", getCurrentThreadstamp(), getCurrentFramestamp(), getCurrentTimestamp());
+    }
+    else
+    {
+        sprintf(str, "MSG: MAIN: (f=%d, t=%d) ", getCurrentFramestamp(), getCurrentTimestamp());
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    int headerlen = strlen(str);
+    int rv = vsnprintf(str + headerlen, sizeof(str) - headerlen, fmt, args);
+    va_end(args);
+
+    OutputDebugStringA(str);
+    return rv;
 }
 #endif
+
 int cmdprintf(const char * fmt, ...)
 {
 	char str[4096];

--- a/wintasee/print.cpp
+++ b/wintasee/print.cpp
@@ -37,20 +37,22 @@ int debugprintf(const char* fmt, ...)
     }
 
     char str[4096];
+    str[ARRAYSIZE(str) - 1] = '\0';
+
     int threadStamp = getCurrentThreadstamp();
     if (threadStamp)
     {
-        _snprintf(str, sizeof(str), "MSG: %08X: (f=%d, t=%d) ", threadStamp, getCurrentFramestamp(), getCurrentTimestamp());
+        _snprintf(str, ARRAYSIZE(str) - 1, "MSG: %08X: (f=%d, t=%d) ", threadStamp, getCurrentFramestamp(), getCurrentTimestamp());
     }
     else
     {
-        _snprintf(str, sizeof(str), "MSG: MAIN: (f=%d, t=%d) ", getCurrentFramestamp(), getCurrentTimestamp());
+        _snprintf(str, ARRAYSIZE(str) - 1, "MSG: MAIN: (f=%d, t=%d) ", getCurrentFramestamp(), getCurrentTimestamp());
     }
 
     va_list args;
     va_start(args, fmt);
     int headerlen = strlen(str);
-    int rv = vsnprintf(str + headerlen, sizeof(str) - headerlen, fmt, args);
+    int rv = vsnprintf(str + headerlen, (ARRAYSIZE(str) - 1) - headerlen, fmt, args);
     va_end(args);
 
     OutputDebugStringA(str);
@@ -60,15 +62,16 @@ int debugprintf(const char* fmt, ...)
 
 int cmdprintf(const char* fmt, ...)
 {
-	char str[4096];
+    char str[4096];
+    str[ARRAYSIZE(str) - 1] = '\0';
 
-	va_list args;
-	va_start(args, fmt);
-	int rv = vsnprintf(str, sizeof(str), fmt, args);
-	va_end(args);
+    va_list args;
+    va_start(args, fmt);
+    int rv = vsnprintf(str, ARRAYSIZE(str) - 1, fmt, args);
+    va_end(args);
 
-	OutputDebugStringA(str);
-	return rv;
+    OutputDebugStringA(str);
+    return rv;
 }
 
 #ifdef ENABLE_LOGGING
@@ -79,25 +82,27 @@ int logprintf_internal(LogCategoryFlag cat, const char* fmt, ...)
         return 0;
     }
 
-	char str[4096];
-	int threadStamp = getCurrentThreadstamp();
+    char str[4096];
+    str[ARRAYSIZE(str) - 1] = '\0';
+
+    int threadStamp = getCurrentThreadstamp();
     if (threadStamp)
     {
-        _snprintf(str, sizeof(str), "LOG: %08X: (f=%d, t=%d, c=%08X) ", threadStamp, getCurrentFramestamp(), getCurrentTimestamp(), cat);
+        _snprintf(str, ARRAYSIZE(str) - 1, "LOG: %08X: (f=%d, t=%d, c=%08X) ", threadStamp, getCurrentFramestamp(), getCurrentTimestamp(), cat);
     }
     else
     {
-        _snprintf(str, sizeof(str), "LOG: MAIN: (f=%d, t=%d, c=%08X) ", getCurrentFramestamp(), getCurrentTimestamp(), cat);
+        _snprintf(str, ARRAYSIZE(str) - 1, "LOG: MAIN: (f=%d, t=%d, c=%08X) ", getCurrentFramestamp(), getCurrentTimestamp(), cat);
     }
 
     va_list args;
     va_start(args, fmt);
     int headerlen = strlen(str);
-	int rv = vsnprintf(str + headerlen, sizeof(str) - headerlen, fmt, args);
-	va_end(args);
+    int rv = vsnprintf(str + headerlen, (ARRAYSIZE(str) - 1) - headerlen, fmt, args);
+    va_end(args);
 
-	OutputDebugStringA(str);
-	return rv;
+    OutputDebugStringA(str);
+    return rv;
 }
 #endif
 

--- a/wintasee/print.h
+++ b/wintasee/print.h
@@ -45,15 +45,21 @@ int cmdprintf(const char* fmt, ...);
 #define registrydebugprintf verbosedebugprintf
 #define timedebugprintf verbosedebugprintf
 
+#define DDRAW_ENTER VERBOSE_ENTER
+#define D3D_ENTER VERBOSE_ENTER
+#define DSOUND_ENTER VERBOSE_ENTER
+#define DMUSIC_ENTER VERBOSE_ENTER
+#define SDL_ENTER VERBOSE_ENTER
+#define GL_ENTER VERBOSE_ENTER
+#define REGISTRY_ENTER VERBOSE_ENTER
+#define TIME_ENTER VERBOSE_ENTER
+
 #if defined(_DEBUG) && 0//1
-	#define verbosedebugprintf debugprintf
+    #define verbosedebugprintf debugprintf
+    #define VERBOSE_ENTER ENTER
 #else
-	#if _MSC_VER > 1310
-		#define verbosedebugprintf(...) ((void)0)
-	#else
-		#define verbosedebugprintf() ((void)0)
-		#pragma warning(disable:4002)
-	#endif
+    #define verbosedebugprintf(...) ((void)0)
+    #define VERBOSE_ENTER(...) ((void)0)
 #endif
 
 
@@ -67,18 +73,10 @@ extern LogCategoryFlag& g_excludeLogFlags;
 #define ENABLE_LOGGING
 
 #ifdef ENABLE_LOGGING
-	int logprintf_internal(LogCategoryFlag cat, const char * fmt, ...);
-	#if _MSC_VER > 1310
-		#define debuglog(cat, ...)         ((((cat) & g_includeLogFlags) && !((cat) & g_excludeLogFlags)) ? logprintf_internal(cat, __VA_ARGS__) : 0)
-	#else
-		#define debuglog(cat, __VA_ARGS__) ((((cat) & g_includeLogFlags) && !((cat) & g_excludeLogFlags)) ? logprintf_internal(cat, __VA_ARGS__) : 0)
-	#endif
+    int logprintf_internal(LogCategoryFlag cat, const char * fmt, ...);
+    #define debuglog(cat, ...)         ((((cat) & g_includeLogFlags) && !((cat) & g_excludeLogFlags)) ? logprintf_internal(cat, __VA_ARGS__) : 0)
 #else
-	#if _MSC_VER > 1310
-		#define debuglog(cat, ...)         0
-	#else
-		#define debuglog(cat, __VA_ARGS__) 0
-	#endif
+    #define debuglog(cat, ...)         0
 #endif
 
 

--- a/wintasee/print.h
+++ b/wintasee/print.h
@@ -11,22 +11,22 @@ int cmdprintf(const char* fmt, ...);
 #define CONCATENATE1(arg1, arg2) CONCATENATE2(arg1, arg2)
 #define CONCATENATE2(arg1, arg2) arg1 ## arg2
 
+// Concatenate with empty because MSVC is a good compiler.
+// (without that it puts all __VA_ARGS__ arguments into the first one)
 #define FMT_ARGS_0(...)
 #define FMT_ARGS_1(arg, ...) #arg " = 0x%lX"
 #define FMT_ARGS_2(arg, ...) #arg " = 0x%lX, " FMT_ARGS_1(__VA_ARGS__)
-#define FMT_ARGS_3(arg, ...) #arg " = 0x%lX, " FMT_ARGS_2(__VA_ARGS__)
-#define FMT_ARGS_4(arg, ...) #arg " = 0x%lX, " FMT_ARGS_3(__VA_ARGS__)
-#define FMT_ARGS_5(arg, ...) #arg " = 0x%lX, " FMT_ARGS_4(__VA_ARGS__)
-#define FMT_ARGS_6(arg, ...) #arg " = 0x%lX, " FMT_ARGS_5(__VA_ARGS__)
-#define FMT_ARGS_7(arg, ...) #arg " = 0x%lX, " FMT_ARGS_6(__VA_ARGS__)
-#define FMT_ARGS_8(arg, ...) #arg " = 0x%lX, " FMT_ARGS_7(__VA_ARGS__)
+#define FMT_ARGS_3(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_2(__VA_ARGS__),)
+#define FMT_ARGS_4(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_3(__VA_ARGS__),)
+#define FMT_ARGS_5(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_4(__VA_ARGS__),)
+#define FMT_ARGS_6(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_5(__VA_ARGS__),)
+#define FMT_ARGS_7(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_6(__VA_ARGS__),)
+#define FMT_ARGS_8(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_7(__VA_ARGS__),)
 
 // Using the MSVC comma erasure for correct handling of 0 arguments.
 #define FOR_EACH_ADD_ARG(...) __0, __VA_ARGS__
 #define FOR_EACH_RSEQ_N() 8, 7, 6, 5, 4, 3, 2, 1, 0
 #define FOR_EACH_ARG_N(__1, __2, __3, __4, __5, __6, __7, __8, __9, N, ...) N
-// Concatenate with empty because MSVC is a good compiler.
-// (without that it puts all __VA_ARGS__ arguments into the first one)
 #define FOR_EACH_NARG_(...) CONCATENATE(FOR_EACH_ARG_N(__VA_ARGS__),)
 #define FOR_EACH_NARG(...) FOR_EACH_NARG_(FOR_EACH_ADD_ARG(__VA_ARGS__), FOR_EACH_RSEQ_N())
 

--- a/wintasee/print.h
+++ b/wintasee/print.h
@@ -33,7 +33,7 @@ int cmdprintf(const char* fmt, ...);
 #define FMT_ARGS_(N, ...) CONCATENATE(FMT_ARGS_, N)(__VA_ARGS__)
 #define FMT_ARGS(...) FMT_ARGS_(FOR_EACH_NARG(__VA_ARGS__), __VA_ARGS__)
 
-#define ENTER(...) debugprintf("%s(" FMT_ARGS(__VA_ARGS__) ") called.\n", __FUNCTION__, __VA_ARGS__);
+#define ENTER(...) debugprintf("%s(" FMT_ARGS(__VA_ARGS__) ") called.\n", __FUNCTION__, __VA_ARGS__)
 
 //#define dinputdebugprintf verbosedebugprintf
 #define ddrawdebugprintf verbosedebugprintf

--- a/wintasee/print.h
+++ b/wintasee/print.h
@@ -4,8 +4,36 @@
 #ifndef PRINT_H_INCL
 #define PRINT_H_INCL
 
-int debugprintf(const char * fmt, ...);
-int cmdprintf(const char * fmt, ...);
+int debugprintf(const char* fmt, ...);
+int cmdprintf(const char* fmt, ...);
+
+#define CONCATENATE(arg1, arg2) CONCATENATE1(arg1, arg2)
+#define CONCATENATE1(arg1, arg2) CONCATENATE2(arg1, arg2)
+#define CONCATENATE2(arg1, arg2) arg1 ## arg2
+
+#define FMT_ARGS_0(...)
+#define FMT_ARGS_1(arg, ...) #arg " = 0x%lX"
+#define FMT_ARGS_2(arg, ...) #arg " = 0x%lX, " FMT_ARGS_1(__VA_ARGS__)
+#define FMT_ARGS_3(arg, ...) #arg " = 0x%lX, " FMT_ARGS_2(__VA_ARGS__)
+#define FMT_ARGS_4(arg, ...) #arg " = 0x%lX, " FMT_ARGS_3(__VA_ARGS__)
+#define FMT_ARGS_5(arg, ...) #arg " = 0x%lX, " FMT_ARGS_4(__VA_ARGS__)
+#define FMT_ARGS_6(arg, ...) #arg " = 0x%lX, " FMT_ARGS_5(__VA_ARGS__)
+#define FMT_ARGS_7(arg, ...) #arg " = 0x%lX, " FMT_ARGS_6(__VA_ARGS__)
+#define FMT_ARGS_8(arg, ...) #arg " = 0x%lX, " FMT_ARGS_7(__VA_ARGS__)
+
+// Using the MSVC comma erasure for correct handling of 0 arguments.
+#define FOR_EACH_ADD_ARG(...) __0, __VA_ARGS__
+#define FOR_EACH_RSEQ_N() 8, 7, 6, 5, 4, 3, 2, 1, 0
+#define FOR_EACH_ARG_N(__1, __2, __3, __4, __5, __6, __7, __8, __9, N, ...) N
+// Concatenate with empty because MSVC is a good compiler.
+// (without that it puts all __VA_ARGS__ arguments into the first one)
+#define FOR_EACH_NARG_(...) CONCATENATE(FOR_EACH_ARG_N(__VA_ARGS__),)
+#define FOR_EACH_NARG(...) FOR_EACH_NARG_(FOR_EACH_ADD_ARG(__VA_ARGS__), FOR_EACH_RSEQ_N())
+
+#define FMT_ARGS_(N, ...) CONCATENATE(FMT_ARGS_, N)(__VA_ARGS__)
+#define FMT_ARGS(...) FMT_ARGS_(FOR_EACH_NARG(__VA_ARGS__), __VA_ARGS__)
+
+#define ENTER(...) debugprintf("%s(" FMT_ARGS(__VA_ARGS__) ") called.\n", __FUNCTION__, __VA_ARGS__);
 
 //#define dinputdebugprintf verbosedebugprintf
 #define ddrawdebugprintf verbosedebugprintf

--- a/wintasee/print.h
+++ b/wintasee/print.h
@@ -11,8 +11,11 @@ int cmdprintf(const char* fmt, ...);
 #define CONCATENATE1(arg1, arg2) CONCATENATE2(arg1, arg2)
 #define CONCATENATE2(arg1, arg2) arg1 ## arg2
 
-// Concatenate with empty because MSVC is a good compiler.
-// (without that it puts all __VA_ARGS__ arguments into the first one)
+/*
+ * Concatenate with empty because otherwise
+ * it puts all __VA_ARGS__ arguments into the first one.
+ * -- YaLTeR
+ */
 #define FMT_ARGS_0(...)
 #define FMT_ARGS_1(arg, ...) #arg " = 0x%lX"
 #define FMT_ARGS_2(arg, ...) #arg " = 0x%lX, " FMT_ARGS_1(__VA_ARGS__)
@@ -23,7 +26,10 @@ int cmdprintf(const char* fmt, ...);
 #define FMT_ARGS_7(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_6(__VA_ARGS__),)
 #define FMT_ARGS_8(arg, ...) #arg " = 0x%lX, " CONCATENATE(FMT_ARGS_7(__VA_ARGS__),)
 
-// Using the MSVC comma erasure for correct handling of 0 arguments.
+/*
+ * Using the MSVC preprocessor comma erasure for
+ * correct handling of 0 arguments.
+ */
 #define FOR_EACH_ADD_ARG(...) __0, __VA_ARGS__
 #define FOR_EACH_RSEQ_N() 8, 7, 6, 5, 4, 3, 2, 1, 0
 #define FOR_EACH_ARG_N(__1, __2, __3, __4, __5, __6, __7, __8, __9, N, ...) N
@@ -73,7 +79,7 @@ extern LogCategoryFlag& g_excludeLogFlags;
 #define ENABLE_LOGGING
 
 #ifdef ENABLE_LOGGING
-    int logprintf_internal(LogCategoryFlag cat, const char * fmt, ...);
+    int logprintf_internal(LogCategoryFlag cat, const char* fmt, ...);
     #define debuglog(cat, ...)         ((((cat) & g_includeLogFlags) && !((cat) & g_excludeLogFlags)) ? logprintf_internal(cat, __VA_ARGS__) : 0)
 #else
     #define debuglog(cat, ...)         0

--- a/wintasee/wintasee.cpp
+++ b/wintasee/wintasee.cpp
@@ -1577,7 +1577,7 @@ bool IsWindows7()     { return tasflags.osVersionMajor == 6 && tasflags.osVersio
 // PostDllMain is the code we run after DllMain to finish up initialization without restrictions.
 DWORD WINAPI PostDllMain(LPVOID lpParam)
 {
-	ENTER(lpParam);
+    ENTER(lpParam);
 	dllInitializationDone = true;
 
 	detTimer.OnSystemTimerRecalibrated();

--- a/wintasee/wintasee.cpp
+++ b/wintasee/wintasee.cpp
@@ -222,7 +222,7 @@ bool redrawingScreen = false;
 
 bool RedrawScreen()
 {
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+    VERBOSE_ENTER();
 	redrawingScreen = true;
 	if(RedrawScreenD3D8())
 	{}
@@ -713,7 +713,7 @@ bool pauseHandlerSuspendedSound = false;
 
 void SaveOrLoad(int slot, bool save)
 {
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+    VERBOSE_ENTER();
 	tls.callerisuntrusted++;
 	if(save && tasflags.storeVideoMemoryInSavestates)
 	{
@@ -752,7 +752,7 @@ void SaveOrLoad(int slot, bool save)
 
 void GetFrameInput()
 {
-	verbosedebugprintf(__FUNCTION__ " called.\n");
+    VERBOSE_ENTER();
 	ProcessFrameInput();
 }
 
@@ -764,7 +764,7 @@ LRESULT CALLBACK MyWndProcA(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPara
 // pausehelper
 void HandlePausedEvents()
 {
-	//verbosedebugprintf(__FUNCTION__ " called. (%d, %d)\n", pauseHandlerContiguousCallCount, pauseHandlerSuspendedSound);
+	//VERBOSE_ENTER(pauseHandlerContiguousCallCount, pauseHandlerSuspendedSound);
 	if(inPauseHandler)
 		return;
 	inPauseHandler = true;
@@ -1320,7 +1320,7 @@ struct MyClassFactory : IClassFactory
 
 	MyClassFactory(IClassFactory* cf) : m_cf(cf)
 	{
-//		debugprintf(__FUNCTION__ " called.\n");
+//		ENTER();
 //		cmdprintf("SHORTTRACE: 3,50");
 	}
 
@@ -1329,7 +1329,7 @@ struct MyClassFactory : IClassFactory
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObj)
 	{
-		//debugprintf(__FUNCTION__ "(0x%X) called.\n", riid.Data1);
+		//ENTER(riid.Data1);
 		HRESULT rv = m_cf->QueryInterface(riid, ppvObj);
 		if(SUCCEEDED(rv))
 			HookCOMInterface(riid, ppvObj);
@@ -1338,13 +1338,13 @@ struct MyClassFactory : IClassFactory
 
     ULONG STDMETHODCALLTYPE AddRef()
 	{
-		//debugprintf(__FUNCTION__ " called.\n");
+		//ENTER();
 		return m_cf->AddRef();
 	}
 
     ULONG STDMETHODCALLTYPE Release()
 	{
-		//debugprintf(__FUNCTION__ " called.\n");
+		//ENTER();
 		ULONG count = m_cf->Release();
 		if(0 == count)
 			delete this;

--- a/wintasee/wintasee.cpp
+++ b/wintasee/wintasee.cpp
@@ -1577,8 +1577,8 @@ bool IsWindows7()     { return tasflags.osVersionMajor == 6 && tasflags.osVersio
 // PostDllMain is the code we run after DllMain to finish up initialization without restrictions.
 DWORD WINAPI PostDllMain(LPVOID lpParam)
 {
+	ENTER(lpParam);
 	dllInitializationDone = true;
-	debugprintf(__FUNCTION__ " called.\n");
 
 	detTimer.OnSystemTimerRecalibrated();
 


### PR DESCRIPTION
https://github.com/Hourglass-Resurrection/Hourglass-Resurrection/issues/22
- Cleaned up the three functions in print.cpp.
- Added a macro `ENTER(...)` for logging entering into functions. `ENTER(a1, b2, c3)` expands to (an equivalent of) `debugprintf("%s(a1 = 0x%lX, b2 = 0x%lX, c3 = 0x%lX) called.\n", __FUNCTION__, a1, b2, c3)`.
- Replaced all applicable debugprintfs with the new ENTERs.
- Removed three printf-related old compiler ifdefs (for different __VA_ARGS__ handling).
