### PR TITLE
BUILD: Automatic builds with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Hourglass Resurrection
 ======================
 
+Automated builds: [Configuration:Debug](https://ci.appveyor.com/api/projects/Warepire/hourglass-resurrection/artifacts/Hourglass-Resurrection-master.zip?branch=master&job=Configuration%3A+Debug) | [Configuration:Release](https://ci.appveyor.com/api/projects/Warepire/hourglass-resurrection/artifacts/Hourglass-Resurrection-master.zip?branch=master&job=Configuration%3A+Release)
+
 Goal
 ----
 This project aims to improve Hourglass, the Windows TASing framework, which was created and maintained by Nitsuja and a few others like upthorn and Lex until 2011. Original project: http://code.google.com/p/hourglass-win32/

--- a/scripts/appveyor.yml
+++ b/scripts/appveyor.yml
@@ -1,0 +1,17 @@
+version: '{build}'
+branches:
+  only:
+  - master
+skip_tags: true
+configuration:
+- Debug
+- Release
+build:
+  project: Hourglass-Resurrection.sln
+  verbosity: minimal
+after_build:
+- cmd: |-
+    IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (SET PACKAGE="%APPVEYOR_PROJECT_NAME%-master") ELSE (SET PACKAGE="%APPVEYOR_PROJECT_NAME%-PR-%APPVEYOR_PULL_REQUEST_NUMBER%")
+    7z a %PACKAGE%.zip %APPVEYOR_BUILD_FOLDER%\build\%CONFIGURATION%\*
+artifacts:
+- path: '*zip'


### PR DESCRIPTION
Figured we could use some sort of super-basic buildbot.
I've set up the repo and appveyor to build the master branch on commit, and every pull request made from here-on.

What's left is to re-configure appveyor to use the included build-rules file so that builds can be reconfigured without access to the account (in case I am gone for a week or so and someone wants to make a quick edit)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hourglass-resurrection/hourglass-resurrection/55)

<!-- Reviewable:end -->
