### PR TITLE
Add .editorconfig

### DIFF
--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.{c,cpp,h,hpp}]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true


### PR DESCRIPTION
Officially supported in VS2017, it removes the need of changing global editor settings around to satisfy multiple projects' coding styles.