### PR TITLE
Add the .vs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 *.VC.opendb
 *.VC.db
 ipch/
+.vs/


### PR DESCRIPTION
Small PR for ignoring the .vs folder, which contains Visual Studio 2017 files.