### PR TITLE
Replace the trustedcaller hack with a debugger command

### DIFF
--- a/source/application/TrustedModule.cpp
+++ b/source/application/TrustedModule.cpp
@@ -1,0 +1,95 @@
+﻿/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "Config.h"
+
+#include "TrustedModule.h"
+
+namespace
+{
+    std::map<DWORD, std::vector<std::wstring>> s_trusted_modules;
+
+    size_t CountSharedPrefixLength(const std::wstring& a, const std::wstring& b)
+    {
+        size_t shortest_path = std::min(a.size(), b.size());
+        size_t i;
+        for (i = 0; i < shortest_path && tolower(a[i]) == tolower(b[i]); ++i)
+        {
+        }
+        return i;
+    }
+
+    UINT CountBackslashes(const std::wstring& str)
+    {
+        return std::count(str.begin(), str.end(), L'\\');
+    }
+
+}
+
+/*
+ * Hacky... yucky
+ * -- Warepire
+ */
+extern std::wstring injected_dll_path;
+extern std::wstring sub_exe_filename;
+
+namespace TrustedModule
+{
+    void OnLoad(DWORD process_id, const std::wstring& path)
+    {
+        /*
+         * If we can "trust" a newly loaded module, add it to the list.
+         */
+        UINT proximity = 2;
+        if (path == injected_dll_path)
+        {
+            s_trusted_modules[process_id].emplace_back(path);
+        }
+        else if (CountBackslashes(Config::exe_filename.c_str() + CountSharedPrefixLength(Config::exe_filename, path)) < proximity)
+        {
+            s_trusted_modules[process_id].emplace_back(path);
+        }
+        else if (CountBackslashes(sub_exe_filename.c_str() + CountSharedPrefixLength(sub_exe_filename, path)) < proximity)
+        {
+            s_trusted_modules[process_id].emplace_back(path);
+        }
+        else if (path.length() >= 4 && (path.substr(path.length() - 4)) == L".cox") // hack, we can generally assume the game outputted any dll that has this extension
+        {
+            s_trusted_modules[process_id].emplace_back(path);
+        }
+    }
+
+    void OnUnload(DWORD process_id, const std::wstring& path)
+    {
+        auto& proc_modules = s_trusted_modules[process_id];
+        auto removed = std::remove_if(proc_modules.begin(), proc_modules.end(),
+                                      [&path](const std::wstring& m) { return (m == path); });
+
+        if (removed == proc_modules.end())
+        {
+            return;
+        }
+        proc_modules.erase(removed, proc_modules.end());
+    }
+
+    bool IsTrusted(DWORD process_id, const std::wstring& path)
+    {
+        auto CheckModule = [&path](const std::wstring &m) {
+            return (path == m);
+        };
+        return (std::find_if(s_trusted_modules[process_id].begin(),
+                             s_trusted_modules[process_id].end(),
+                             CheckModule) != s_trusted_modules[process_id].end());
+    }
+}

--- a/source/application/TrustedModule.h
+++ b/source/application/TrustedModule.h
@@ -1,0 +1,21 @@
+﻿/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <string>
+
+namespace TrustedModule
+{
+    void OnLoad(DWORD process_id, const std::wstring& path);
+
+    void OnUnload(DWORD process_id, const std::wstring& path);
+
+    bool IsTrusted(DWORD process_id, const std::wstring& path);
+}

--- a/source/application/application.vcxproj
+++ b/source/application/application.vcxproj
@@ -144,6 +144,7 @@
     <ClCompile Include="AVIDumping\AVIDumper.cpp" />
     <ClCompile Include="AVIDumping\WaitableBool.cpp" />
     <ClCompile Include="AVIDumping\WaveFormat.cpp" />
+    <ClCompile Include="TrustedModule.cpp" />
     <ClCompile Include="Utils\File\ExecutableFileHeaders.cpp" />
     <ClCompile Include="Utils\File\FileDialog.cpp" />
     <ClCompile Include="Config.cpp" />
@@ -211,6 +212,7 @@
     <ClInclude Include="..\shared\version.h" />
     <ClInclude Include="..\shared\winutil.h" />
     <ClInclude Include="Resource.h" />
+    <ClInclude Include="TrustedModule.h" />
     <ClInclude Include="Utils\File.h" />
     <ClInclude Include="Utils\COM.h" />
   </ItemGroup>

--- a/source/application/application.vcxproj.filters
+++ b/source/application/application.vcxproj.filters
@@ -125,6 +125,9 @@
     <ClCompile Include="Utils\File\ExecutableFileHeaders.cpp">
       <Filter>Source Files\Utils\File</Filter>
     </ClCompile>
+    <ClCompile Include="TrustedModule.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CustomDLGs.h">
@@ -246,6 +249,9 @@
     </ClInclude>
     <ClInclude Include="DbgHelp\DiaEnumIterator.h">
       <Filter>Source Files\DbgHelp</Filter>
+    </ClInclude>
+    <ClInclude Include="TrustedModule.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/source/application/ramsearch.cpp
+++ b/source/application/ramsearch.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 // A few notes about this implementation of a RAM search window:
@@ -170,10 +170,6 @@ void RamSearchSaveUndoStateIfNotTooBig(HWND hDlg);
 static const int tooManyRegionsForUndo = 10000;
 
 
-
-bool IsInNonCurrentYetTrustedAddressSpace(DWORD address);
-
-
 void ResetMemoryRegions()
 {
 //	Clear_Sound_Buffer();
@@ -215,8 +211,8 @@ void ResetMemoryRegions()
 				//if((unsigned int)mbi.BaseAddress > 0x00400000 + 0x00800000
 				//&& ((unsigned int)mbi.BaseAddress < 0x7ff00000 || (unsigned int)mbi.BaseAddress >= 0x80000000))
 				//	continue; // 0x7f000000  ... 0x7ffb0000
-				if(!IsInNonCurrentYetTrustedAddressSpace((unsigned int)mbi.BaseAddress))
-					continue;
+				/*if(!IsInNonCurrentYetTrustedAddressSpace((unsigned int)mbi.BaseAddress))
+					continue;*/
 				//BOOL a = (mbi.State & MEM_PRIVATE);
 				//BOOL b = (mbi.State & MEM_IMAGE);
 				//BOOL c = (mbi.State & MEM_MAPPED);

--- a/source/hooks/dettime.cpp
+++ b/source/hooks/dettime.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "wintasee.h"
@@ -150,18 +150,17 @@ DWORD DeterministicTimer::GetTicks(TimeCallType type)
     //		LONG untrustedCaller = tls.callerisuntrusted;
 
     BOOL isFrameThread;
-    LONG untrustedCaller;
+    bool untrustedCaller = false;
     if (ThreadLocalStuff* pCurtls = ThreadLocalStuff::GetIfAllocated())
     {
         isFrameThread = tls_IsPrimaryThread2(pCurtls);
-        untrustedCaller = pCurtls->callerisuntrusted;
         if (type != TIMETYPE_UNTRACKED)
-            untrustedCaller = !VerifyIsTrustedCaller(!untrustedCaller);
+            untrustedCaller = !VerifyIsTrustedCaller();
     }
     else
     {
         isFrameThread = FALSE;
-        untrustedCaller = TRUE;
+        untrustedCaller = true;
     }
 
     //verbosedebugprintf(__FUNCTION__ " called (%d).\n", ticks);

--- a/source/hooks/hooks/d3d8hooks.cpp
+++ b/source/hooks/hooks/d3d8hooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "external/d3d8.h"
@@ -1011,12 +1011,9 @@ namespace Hooks
     HOOKFUNC IDirect3D8* WINAPI MyDirect3DCreate8(UINT SDKVersion)
     {
         ENTER();
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         IDirect3D8* rv = Direct3DCreate8(SDKVersion);
         if (SUCCEEDED(rv))
             HookCOMInterface(IID_IDirect3D8, (void**)&rv);
-        curtls.callerisuntrusted--;
         return rv;
     }
 

--- a/source/hooks/hooks/d3d9hooks.cpp
+++ b/source/hooks/hooks/d3d9hooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "external/d3d9.h"
@@ -1003,12 +1003,9 @@ namespace Hooks
     HOOKFUNC IDirect3D9* WINAPI MyDirect3DCreate9(UINT SDKVersion)
     {
         ENTER();
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         IDirect3D9* rv = Direct3DCreate9(SDKVersion);
         if (SUCCEEDED(rv))
             HookCOMInterface(IID_IDirect3D9, (void**)&rv);
-        curtls.callerisuntrusted--;
         return rv;
     }
 

--- a/source/hooks/hooks/d3dhooks.cpp
+++ b/source/hooks/hooks/d3dhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "external/d3d.h"
@@ -434,15 +434,12 @@ namespace Hooks
     HOOKFUNC HRESULT WINAPI MyDirect3DCreate(UINT SDKVersion, LPUNKNOWN* lplpd3d, LPUNKNOWN pUnkOuter)
     {
         ENTER(SDKVersion);
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         HRESULT rv = Direct3DCreate(SDKVersion, lplpd3d, pUnkOuter);
         if (SUCCEEDED(rv))
         {
             HookCOMInterfaceUnknownVT(IDirect3D, *lplpd3d);
             //HookCOMInterface(IID_IDirect3D, (LPVOID*)lplpd3d);
         }
-        curtls.callerisuntrusted--;
         return rv;
     }
     HOOK_FUNCTION(HRESULT, WINAPI, Direct3DCreate7,
@@ -450,15 +447,12 @@ namespace Hooks
     HOOKFUNC HRESULT WINAPI MyDirect3DCreate7(UINT SDKVersion, LPUNKNOWN* lplpd3d, LPUNKNOWN pUnkOuter)
     {
         ENTER(SDKVersion);
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         HRESULT rv = Direct3DCreate7(SDKVersion, lplpd3d, pUnkOuter);
         if (SUCCEEDED(rv))
         {
             HookCOMInterfaceUnknownVT(IDirect3D7, *lplpd3d);
             //HookCOMInterface(IID_IDirect3D7, (LPVOID*)lplpd3d); // doesn't work in Ninjah
         }
-        curtls.callerisuntrusted--;
         return rv;
     }
     HOOK_FUNCTION(HRESULT, WINAPI, Direct3DCreateDevice,
@@ -467,12 +461,9 @@ namespace Hooks
     {
         // maybe unnecessary?
         ENTER(lpGUID->Data1, lpd3ddevice);
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         HRESULT rv = Direct3DCreateDevice(lpGUID, lpd3ddevice, surf, lplpd3ddevice, pUnkOuter);
         if (SUCCEEDED(rv))
             HookCOMInterfaceUnknownVT(IDirect3DDevice, *lplpd3ddevice);
-        curtls.callerisuntrusted--;
         return rv;
     }
     HOOK_FUNCTION(HRESULT, WINAPI, Direct3DCreateDevice7,
@@ -481,12 +472,9 @@ namespace Hooks
     {
         // maybe unnecessary?
         ENTER(lpGUID->Data1, lpd3ddevice);
-        ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         HRESULT rv = Direct3DCreateDevice7(lpGUID, lpd3ddevice, surf, lplpd3ddevice, pUnkOuter);
         if (SUCCEEDED(rv))
             HookCOMInterfaceUnknownVT(IDirect3DDevice7, *lplpd3ddevice);
-        curtls.callerisuntrusted--;
         return rv;
     }
 

--- a/source/hooks/hooks/gdihooks.cpp
+++ b/source/hooks/hooks/gdihooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "../wintasee.h"
@@ -245,7 +245,7 @@ namespace Hooks
                 if (hwnd /*&& !hwndRespondingToPaintMessage[hwnd]*/)
                 {
                     if ((/*s_gdiPhaseDetector.AdvanceAndCheckCycleBoundary(MAKELONG(nXOriginDest,nYOriginDest))
-                        ||*/ tls.peekedMessage) && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+                        ||*/ tls.peekedMessage) && VerifyIsTrustedCaller())
                     {
                         if ((nWidthSrc >= gdiFrameBigEnoughWidth && nHeightSrc >= gdiFrameBigEnoughHeight)
                             || HDCSizeBigEnoughForFrameBoundary(hdcSrc))
@@ -310,7 +310,7 @@ namespace Hooks
                 if (hwnd /*&& !hwndRespondingToPaintMessage[hwnd]*/)
                 {
                     if ((/*s_gdiPhaseDetector.AdvanceAndCheckCycleBoundary(MAKELONG(nXDest,nYDest))
-                        ||*/ tls.peekedMessage) && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+                        ||*/ tls.peekedMessage) && VerifyIsTrustedCaller())
                     {
                         if ((nWidth >= gdiFrameBigEnoughWidth && nHeight >= gdiFrameBigEnoughHeight)
                             || HDCSizeBigEnoughForFrameBoundary(hdcSrc))
@@ -414,7 +414,7 @@ namespace Hooks
             if (hwnd /*&& !hwndRespondingToPaintMessage[hwnd]*/)
             {
                 if (rv != 0 && rv != GDI_ERROR && (/*s_gdiPhaseDetector.AdvanceAndCheckCycleBoundary(MAKELONG(xDest,yDest))
-                    ||*/ tls.peekedMessage) && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+                    ||*/ tls.peekedMessage) && VerifyIsTrustedCaller())
                 {
                     if (!(tasflags.aviMode & 1))
                         FrameBoundary(NULL, CAPTUREINFO_TYPE_NONE);
@@ -438,7 +438,7 @@ namespace Hooks
             if (hwnd /*&& !hwndRespondingToPaintMessage[hwnd]*/)
             {
                 if (rv != 0 && rv != GDI_ERROR && rop == SRCCOPY && (/*s_gdiPhaseDetector.AdvanceAndCheckCycleBoundary(MAKELONG(xDest,yDest))
-                    ||*/ tls.peekedMessage) && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+                    ||*/ tls.peekedMessage) && VerifyIsTrustedCaller())
                 {
                     if (!(tasflags.aviMode & 1))
                         FrameBoundary(NULL, CAPTUREINFO_TYPE_NONE);

--- a/source/hooks/hooks/inputhooks.cpp
+++ b/source/hooks/hooks/inputhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include <vector>
@@ -1000,8 +1000,6 @@ namespace Hooks
             STDMETHOD(CreateDevice)(REFGUID rguid, IDirectInputDeviceN** device, LPUNKNOWN unknown)
             {
                 ENTER();
-                ThreadLocalStuff& curtls = tls;
-                curtls.callerisuntrusted++;
                 HRESULT hr = m_di->CreateDevice(rguid, device, unknown);
                 if (SUCCEEDED(hr))
                 {
@@ -1010,7 +1008,6 @@ namespace Hooks
                     // (at least if rguid == GUID_SysKeyboard that's what it'll do)
                     HookCOMInterfaceEx(IID_IDirectInputDeviceN, (LPVOID*)device, rguid);
                 }
-                curtls.callerisuntrusted--;
 
                 return hr;
             }
@@ -1021,10 +1018,7 @@ namespace Hooks
                 // FIXME: NYI.
                 // this is leaking data to the game!
                 // for now, let's at least untrust it.
-                ThreadLocalStuff& curtls = tls;
-                curtls.callerisuntrusted++;
                 HRESULT rv = m_di->EnumDevices(devType, callback, ref, flags);
-                curtls.callerisuntrusted--;
                 return rv;
             }
 
@@ -1049,12 +1043,9 @@ namespace Hooks
             STDMETHOD(CreateDeviceEx)(REFGUID a, REFIID b, LPVOID* c, LPUNKNOWN d)
             {
                 ENTER(a.Data1, b.Data1);
-                ThreadLocalStuff& curtls = tls;
-                curtls.callerisuntrusted++;
                 HRESULT hr = m_di->CreateDeviceEx(a, b, c, d);
                 if (SUCCEEDED(hr))
                     HookCOMInterface(b, c);
-                curtls.callerisuntrusted--;
                 return hr;
             }
 
@@ -1436,7 +1427,6 @@ namespace Hooks
             ThreadLocalStuff& curtls = tls;
             const char* oldName = curtls.curThreadCreateName;
             curtls.curThreadCreateName = "DirectInput";
-            curtls.callerisuntrusted++;
             HRESULT rv = DirectInputCreateA(hinst, dwVersion, ppDI, punkOuter);
 
             if (SUCCEEDED(rv))
@@ -1455,7 +1445,6 @@ namespace Hooks
                 LOG() << "DirectInputCreateA FAILED, all on its own. Returned " << rv;
             }
             curtls.curThreadCreateName = oldName;
-            curtls.callerisuntrusted--;
 
             return rv;
         }
@@ -1466,7 +1455,6 @@ namespace Hooks
             ThreadLocalStuff& curtls = tls;
             const char* oldName = curtls.curThreadCreateName;
             curtls.curThreadCreateName = "DirectInput";
-            curtls.callerisuntrusted++;
             HRESULT rv = DirectInputCreateW(hinst, dwVersion, ppDI, punkOuter);
 
             if (SUCCEEDED(rv))
@@ -1485,7 +1473,6 @@ namespace Hooks
                 LOG() << "DirectInputCreateW FAILED, all on its own. Returned " << rv;
             }
             curtls.curThreadCreateName = oldName;
-            curtls.callerisuntrusted--;
 
             return rv;
         }
@@ -1495,7 +1482,6 @@ namespace Hooks
         {
             ENTER();
             ThreadLocalStuff& curtls = tls;
-            curtls.callerisuntrusted++;
             const char* oldName = curtls.curThreadCreateName;
             curtls.curThreadCreateName = "directinputex";
             HRESULT rv = DirectInputCreateEx(hinst, dwVersion, riidltf, ppvOut, punkOuter);
@@ -1509,7 +1495,6 @@ namespace Hooks
                 LOG() << "DirectInputCreateEx FAILED, all on its own. Returned " << rv;
             }
             curtls.curThreadCreateName = oldName;
-            curtls.callerisuntrusted--;
             return rv;
         }
 
@@ -1519,7 +1504,6 @@ namespace Hooks
         {
             ENTER();
             ThreadLocalStuff& curtls = tls;
-            curtls.callerisuntrusted++;
             const char* oldName = curtls.curThreadCreateName;
             curtls.curThreadCreateName = "directinput8";
             HRESULT rv = DirectInput8Create(hinst, dwVersion, riidltf, ppvOut, punkOuter);
@@ -1533,7 +1517,6 @@ namespace Hooks
                 LOG() << "DirectInput8Create FAILED, all on its own. Returned " << rv;
             }
             curtls.curThreadCreateName = oldName;
-            curtls.callerisuntrusted--;
             return rv;
         }
 

--- a/source/hooks/hooks/messagehooks.cpp
+++ b/source/hooks/hooks/messagehooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "../wintasee.h"
@@ -468,7 +468,7 @@ namespace Hooks
 	    case WM_SYSCOMMAND:
 		    return MAF_BYPASSGAME | MAF_RETURN_CUSTOM;
 	    case WM_COMMAND:
-		    if(VerifyIsTrustedCaller(!tls.callerisuntrusted))
+		    if(VerifyIsTrustedCaller())
 			    return MAF_PASSTHROUGH | MAF_RETURN_OS; // hack to fix F2 command in Eternal Daughter
 		    break;
 	    default:
@@ -652,9 +652,8 @@ namespace Hooks
     // MyWndProcInternal
     LRESULT DispatchMessageInternal(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam, bool ascii/*=true*/, MessageActionFlags maf/*=MAF_PASSTHROUGH|MAF_RETURN_OS*/)
     {
-	    LONG untrusted = tls.callerisuntrusted;
 	    //untrusted = VerifyIsTrustedCaller(!untrusted) ? 0 : (untrusted ? untrusted : 1);
-	    if(/*inPauseHandler || */(untrusted  > (InSendMessage()?1:0))) // if it's the OS or pause handler calling us back,
+	    if(/*inPauseHandler || */VerifyIsTrustedCaller()) // if it's the OS or pause handler calling us back,
 	    {                                 // we can't rely on it doing so consistently across systems,
 		    if(!(maf & (MAF_INTERCEPT|MAF_BYPASSGAME)))
 		    {
@@ -946,7 +945,7 @@ namespace Hooks
                   << ") denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message " << Msg << "(" << GetWindowsMessageName(Msg)
                   << ") denied because the caller is untrusted.";
@@ -994,7 +993,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1044,7 +1043,7 @@ namespace Hooks
 			    *lpdwResult = 1;
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    if(lpdwResult)
@@ -1097,7 +1096,7 @@ namespace Hooks
 			    *lpdwResult = 1;
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    if(lpdwResult)
@@ -1148,7 +1147,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1208,7 +1207,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1270,7 +1269,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1306,7 +1305,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1341,7 +1340,7 @@ namespace Hooks
 		    //cmdprintf("SHORTTRACE: 3,50");
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1365,9 +1364,7 @@ namespace Hooks
 	    //if(tls.isFrameThread)
 	    if(tls_IsPrimaryThread() || tasflags.messageSyncMode == 2)
 	    {
-			    tls.callerisuntrusted++;
 		    BOOL rv = PostMessageW(hWnd, whitelistUserMessage(Msg), wParam, lParam);
-			    tls.callerisuntrusted--;
 		    return rv;
 	    }
 	    else
@@ -1396,7 +1393,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1422,12 +1419,10 @@ namespace Hooks
 	    //if(tls.isFrameThread)
 	    if(tls_IsPrimaryThread() || tasflags.messageSyncMode >= 2)
 	    {
-			    tls.callerisuntrusted++;
 	    //	if(tasflags.threadMode == 2 || tasflags.threadMode == 3)
 			    rv = PostMessageA(hWnd, whitelistUserMessage(Msg), wParam, lParam);
 	    //	else
 	    //		rv = SendMessageA(hWnd, Msg, wParam, lParam);
-			    tls.callerisuntrusted--;
 		    return rv;
 	    }
 	    else
@@ -1453,7 +1448,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
             LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1478,9 +1473,7 @@ namespace Hooks
 		    return 0;
 	    }
     #else
-	    tls.callerisuntrusted++;
 	    LRESULT rv = PostThreadMessageA(idThread, whitelistUserMessage(Msg), wParam, lParam);
-	    tls.callerisuntrusted--;
 	    return rv;
     #endif
     }
@@ -1494,7 +1487,7 @@ namespace Hooks
             LOG() << "message denied because it's in a reserved range.";
 		    return 1;
 	    }
-	    if(tls.callerisuntrusted)
+	    if (VerifyIsTrustedCaller())
 	    {
 		    LOG() << "message denied because the caller is untrusted.";
 		    return 1;
@@ -1519,9 +1512,7 @@ namespace Hooks
 		    return 0;
 	    }
     #else
-	    tls.callerisuntrusted++;
 	    LRESULT rv = PostThreadMessageW(idThread, whitelistUserMessage(Msg), wParam, lParam);
-	    tls.callerisuntrusted--;
 	    return rv;
     #endif
     }
@@ -1672,17 +1663,13 @@ namespace Hooks
     //		if(tasflags.threadMode == 2 /*|| tasflags.threadMode == 3*/ /*|| !tls_IsPrimaryThread()*/)
 		    if(tasflags.framerate <= 0 && tasflags.messageSyncMode != 0)
 		    {
-			    tls.callerisuntrusted++;
 			    rv = GetMessageA(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
-			    tls.callerisuntrusted--;
 		    }
 		    else
 		    {
     //			while(!rv /*|| !CanMessageReachGame(lpMsg)*/)
 			    {
-				    tls.callerisuntrusted++;
 				    rv = PeekMessageA(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, PM_REMOVE);
-				    tls.callerisuntrusted--;
 			    }
 		    }
             LOG() << "got message " << lpMsg->hwnd << ", " << lpMsg->message << " ("
@@ -1694,7 +1681,7 @@ namespace Hooks
 		    if(rv && (CanMessageReachGame(lpMsg)))
 		    {
 			    //if(!inPauseHandler)
-			    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+			    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller())
 				    tls.peekedMessage = TRUE;
 			    FinalizeWndProcMessage(lpMsg);
 			    return rv;
@@ -1780,17 +1767,13 @@ namespace Hooks
 		    BOOL rv = FALSE;
 		    if(tasflags.messageSyncMode >= 2 || (!tls_IsPrimaryThread() && tasflags.messageSyncMode != 0))
 		    {
-			    tls.callerisuntrusted++;
 			    rv = GetMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax);
-			    tls.callerisuntrusted--;
 		    }
 		    else
 		    {
 			    //while(!rv /*|| !CanMessageReachGame(lpMsg)*/)
 			    {
-				    tls.callerisuntrusted++;
 				    rv = PeekMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, PM_REMOVE);
-				    tls.callerisuntrusted--;
 				    //if(!rv)
 				    //	MySleep(1);
 			    }
@@ -1800,7 +1783,7 @@ namespace Hooks
 		    if(!rv || (CanMessageReachGame(lpMsg)))
 		    {
 			    //if(!inPauseHandler)
-			    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+			    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller())
 				    tls.peekedMessage = TRUE;
 			    FinalizeWndProcMessage(lpMsg);
 			    return rv;
@@ -1877,9 +1860,7 @@ namespace Hooks
 	    wRemoveMsg |= PM_NOYIELD; // testing
 	    while(true)
 	    {
-		    tls.callerisuntrusted++;
 		    BOOL rv = PeekMessageA(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
-		    tls.callerisuntrusted--;
 
 		    if(!rv || (CanMessageReachGame(lpMsg)))
 		    {
@@ -1891,7 +1872,7 @@ namespace Hooks
 				    detTimer.GetTicks(TIMETYPE_CRAWLHACK); // potentially desync prone (but some games will need it) ... moving it here (on no-result) helped sync a bit though... and the problem that happens here is usually caused by GetMessageActionFlags being incomplete
 			    //if(!inPauseHandler)
 			    {
-				    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+				    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller())
 					    tls.peekedMessage = TRUE;
     //				ThreadBoundary(100);
 			    }
@@ -1976,9 +1957,7 @@ namespace Hooks
 	    wRemoveMsg |= PM_NOYIELD; // testing
 	    while(true)
 	    {
-		    tls.callerisuntrusted++;
 		    BOOL rv = PeekMessageW(lpMsg, hWnd, wMsgFilterMin, wMsgFilterMax, wRemoveMsg);
-		    tls.callerisuntrusted--;
 
 		    if(!rv || (CanMessageReachGame(lpMsg)))
 		    {
@@ -1990,7 +1969,7 @@ namespace Hooks
 				    detTimer.GetTicks(TIMETYPE_CRAWLHACK); // potentially desync prone (but some games will need it) ... moving it here (on no-result) helped sync a bit though... and the problem that happens here is usually caused by GetMessageActionFlags being incomplete
 			    //if(!inPauseHandler)
 			    {
-				    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+				    if(tls_IsPrimaryThread() && VerifyIsTrustedCaller())
 					    tls.peekedMessage = TRUE;
     //				ThreadBoundary(100);
 			    }
@@ -2058,18 +2037,14 @@ namespace Hooks
     HOOKFUNC LRESULT WINAPI MyDefWindowProcA(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
     {
 	    ENTER(hWnd, Msg, GetWindowsMessageName(Msg), wParam, lParam);
-	    tls.callerisuntrusted++;
 	    LRESULT rv = DefWindowProcA(hWnd, Msg, wParam, lParam);
-	    tls.callerisuntrusted--;
 	    return rv;
     }
     HOOK_FUNCTION(LRESULT, WINAPI, DefWindowProcW, HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam);
     HOOKFUNC LRESULT WINAPI MyDefWindowProcW(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
     {
 	    ENTER(hWnd, Msg, GetWindowsMessageName(Msg), wParam, lParam);
-	    tls.callerisuntrusted++;
 	    LRESULT rv = DefWindowProcW(hWnd, Msg, wParam, lParam);
-	    tls.callerisuntrusted--;
 	    return rv;
     }
 

--- a/source/hooks/hooks/registryhooks.cpp
+++ b/source/hooks/hooks/registryhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "../wintasee.h"
@@ -165,11 +165,9 @@ namespace Hooks
     {
         ENTER(nIndex);
         ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         curtls.treatDLLLoadsAsClient++;
         int systemResult = GetSystemMetrics(nIndex);
         curtls.treatDLLLoadsAsClient--;
-        curtls.callerisuntrusted--;
         int rv = systemResult;
         switch (nIndex)
         {

--- a/source/hooks/hooks/soundhooks.cpp
+++ b/source/hooks/hooks/soundhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "external/dsound.h"
@@ -1130,9 +1130,7 @@ namespace Hooks
 		        ENTER(this);
 		        //bool dst = disableSelfTicking;
 		        //disableSelfTicking = true;
-		        tls.callerisuntrusted++;
 		        ULONG count = m_dsb->Release();
-		        tls.callerisuntrusted--;
 		        //disableSelfTicking = dst;
 		        if(0 == count)
 			        delete this;
@@ -1732,11 +1730,9 @@ namespace Hooks
 		        ThreadLocalStuff& curtls = tls;
 		        const char* oldName = curtls.curThreadCreateName;
 		        curtls.curThreadCreateName = "DirectSound";
-		        curtls.callerisuntrusted++;
 		
 		        HRESULT rv = m_ds->Initialize(pcGuidDevice);
 		
-		        curtls.callerisuntrusted--;
 		        curtls.curThreadCreateName = oldName;
 		        return rv;
 	        }
@@ -2630,12 +2626,8 @@ namespace Hooks
             // MymciSendCommandA seems to call MymciSendCommandW at least once internally so maybe this isn't necessary,
             // but I'll keep it in case some other OS version skips that step.
 
-            ThreadLocalStuff& curtls = tls;
-            curtls.callerisuntrusted++; // helps Eternal Daughter sync (especially when fast-forwarding with sleep skip on) and allows us to help prevent Iji deadlock in MyWaitForMultipleObjects when threads are enabled
-
             MCIERROR rv = mciSendCommandA(mciId, uMsg, dwParam1, dwParam2);
 
-            curtls.callerisuntrusted--;
             return rv;
         }
 
@@ -2643,18 +2635,16 @@ namespace Hooks
         HOOKFUNC MCIERROR WINAPI MymciSendCommandW(MCIDEVICEID mciId, UINT uMsg, DWORD_PTR dwParam1, DWORD_PTR dwParam2)
         {
             ThreadLocalStuff& curtls = tls;
-            curtls.callerisuntrusted++;
 
-            const char* oldName = tls.curThreadCreateName;
+            const char* oldName = curtls.curThreadCreateName;
             if (!oldName) // in this case, only suggest a name if the caller hasn't already
                 tls.curThreadCreateName = "MediaControl";
 
             MCIERROR rv = mciSendCommandW(mciId, uMsg, dwParam1, dwParam2);
 
             if (!oldName)
-                tls.curThreadCreateName = oldName;
+                curtls.curThreadCreateName = oldName;
 
-            curtls.callerisuntrusted--;
             return rv;
         }
     }
@@ -2681,7 +2671,6 @@ namespace Hooks
                 //else
             {
                 ThreadLocalStuff& curtls = tls;
-                curtls.callerisuntrusted++;
 
                 const char* oldName = curtls.curThreadCreateName;
                 curtls.curThreadCreateName = "DirectSound";
@@ -2705,7 +2694,6 @@ namespace Hooks
                         rv = DS_OK;
                     }
                 }
-                curtls.callerisuntrusted--;
                 curtls.curThreadCreateName = oldName;
                 return rv;
             }
@@ -2730,7 +2718,6 @@ namespace Hooks
                 //else
             {
                 ThreadLocalStuff& curtls = tls;
-                curtls.callerisuntrusted++;
 
                 const char* oldName = curtls.curThreadCreateName;
                 curtls.curThreadCreateName = "DirectSound8";
@@ -2756,7 +2743,6 @@ namespace Hooks
                 }
 
                 curtls.curThreadCreateName = oldName;
-                curtls.callerisuntrusted--;
                 return rv;
             }
         }

--- a/source/hooks/hooks/threadhooks.cpp
+++ b/source/hooks/hooks/threadhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include <map>
@@ -152,7 +152,7 @@ namespace Hooks
         ENTER(lpStartAddress, tls.curThreadCreateName);
         //cmdprintf("SHORTTRACE: 3,50");
 
-        if (tasflags.threadMode == 0 || tasflags.threadMode == 3 && !tls.curThreadCreateName || tasflags.threadMode == 4 && tls.curThreadCreateName || (tasflags.threadMode == 5 && !VerifyIsTrustedCaller(!tls.callerisuntrusted)))
+        if (tasflags.threadMode == 0 || tasflags.threadMode == 3 && !tls.curThreadCreateName || tasflags.threadMode == 4 && tls.curThreadCreateName || (tasflags.threadMode == 5 && !VerifyIsTrustedCaller()))
         {
             const char* threadTypeName = tls.curThreadCreateName;
             LOG() << "thread creation denied. name=" << (threadTypeName ? threadTypeName : "unknown_thread");
@@ -387,7 +387,6 @@ namespace Hooks
             while (true)
                 SuspendThread(hThread);
         }
-        tls.callerisuntrusted++;
         ExitThread(dwExitCode);
     }
 

--- a/source/hooks/hooks/waithooks.cpp
+++ b/source/hooks/hooks/waithooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "../wintasee.h"
@@ -27,7 +27,7 @@ namespace Hooks
     //		// we ignore <5 millisecond sleeps here because they can accumulate in our timer
     //		// to make the game run at a lower framerate than it naturally does.
     //		if(dwMilliseconds >= 5)
-            if (VerifyIsTrustedCaller(!tls.callerisuntrusted))
+            if (VerifyIsTrustedCaller())
                 detTimer.AddDelay(dwMilliseconds, TRUE, TRUE);
 
             dwMilliseconds = 0;
@@ -57,7 +57,7 @@ namespace Hooks
         BOOL isFrameThread = tls_IsPrimaryThread();//tls.isFrameThread;
 
         //if(dwMilliseconds && s_frameThreadId == GetCurrentThreadId()) // main thread waiting?
-        if (dwMilliseconds && isFrameThread && !(bAlertable || !VerifyIsTrustedCaller(!tls.callerisuntrusted)))
+        if (dwMilliseconds && isFrameThread && !(bAlertable || !VerifyIsTrustedCaller()))
         {
             // add a delay for framerate adjustment and to take large sleeps into account.
     //		// we ignore <5 millisecond sleeps here because they can accumulate in our timer
@@ -119,7 +119,7 @@ namespace Hooks
             if (dwMilliseconds > 0)
             {
                 //	if(tls.isFrameThread && !tls.callerisuntrusted) // only apply this to the main thread
-                if (tls_IsPrimaryThread() && VerifyIsTrustedCaller(!tls.callerisuntrusted)) // only apply this to the main thread
+                if (tls_IsPrimaryThread() && VerifyIsTrustedCaller()) // only apply this to the main thread
                 {
                     // add the delay logically but don't physically wait yet
     //				if(rly){
@@ -330,7 +330,7 @@ namespace Hooks
                 // for eversion with multithreading disabled
                 dwMilliseconds = 0;
             }
-            else if (!tls.callerisuntrusted) // hack: if caller is untrusted already, it would have more trouble causing desync than otherwise, so in that case let it wait naturally to avoid frequent deadlocks in quartz.dll at Iji loading screens
+            else if (VerifyIsTrustedCaller()) // hack: if caller is untrusted already, it would have more trouble causing desync than otherwise, so in that case let it wait naturally to avoid frequent deadlocks in quartz.dll at Iji loading screens
             {
                 //if(dwMilliseconds == 0)
                 //{

--- a/source/hooks/hooks/windowhooks.cpp
+++ b/source/hooks/hooks/windowhooks.cpp
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #include "../wintasee.h"
@@ -43,7 +43,6 @@ namespace Hooks
         HWND oldGamehwnd = gamehwnd;
 
         ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         curtls.treatDLLLoadsAsClient++;
         HWND hwnd = CreateWindowExA(dwExStyle, lpClassName,
             lpWindowName, dwStyle, X, Y, nWidth, nHeight,
@@ -52,7 +51,6 @@ namespace Hooks
         MySetWindowTextA(hwnd, lpWindowName);
 
         curtls.treatDLLLoadsAsClient--;
-        curtls.callerisuntrusted--;
         LOG() << "made hwnd = " << hwnd;
 #ifdef EMULATE_MESSAGE_QUEUES
         if (hwnd)
@@ -157,13 +155,11 @@ namespace Hooks
         createWindowDepth++;
         HWND oldGamehwnd = gamehwnd;
         ThreadLocalStuff& curtls = tls;
-        curtls.callerisuntrusted++;
         curtls.treatDLLLoadsAsClient++;
         HWND hwnd = CreateWindowExW(dwExStyle, lpClassName,
             lpWindowName, dwStyle, X, Y, nWidth, nHeight,
             hWndParent, hMenu, hInstance, lpParam);
         curtls.treatDLLLoadsAsClient--;
-        curtls.callerisuntrusted--;
         LOG() << "made hwnd = " << hwnd;
 #ifdef EMULATE_MESSAGE_QUEUES
         if (hwnd)
@@ -492,7 +488,7 @@ namespace Hooks
         // IsWindowFakeFullscreen checks disabled because they let window position info leak to Eternal Daughter and possibly others (maybe need to use ::IsChild inside IsWindowFakeFullscreen)
         // VerifyIsTrustedCaller checks added as a hack so that DirectDrawClipper can still get the real window coordinates
         // TODO: instead of calling VerifyIsTrustedCaller we could probably have MyDirectDrawSurface::MyBlt set a flag for us. although maybe this way is safer.
-        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller())
         {
             if (!lpRect)
                 return FALSE;
@@ -508,7 +504,7 @@ namespace Hooks
     HOOKFUNC BOOL WINAPI MyGetWindowRect(HWND hWnd, LPRECT lpRect)
     {
         // see coments in MyGetClientRect
-        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller())
         {
             if (!lpRect)
                 return FALSE;
@@ -525,7 +521,7 @@ namespace Hooks
     HOOKFUNC BOOL WINAPI MyClientToScreen(HWND hWnd, LPPOINT lpPoint)
     {
         // see coments in MyGetClientRect
-        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller())
         {
             return (lpPoint != NULL);
         }
@@ -535,7 +531,7 @@ namespace Hooks
     HOOKFUNC BOOL WINAPI MyScreenToClient(HWND hWnd, LPPOINT lpPoint)
     {
         // see coments in MyGetClientRect
-        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller(!tls.callerisuntrusted))
+        if (fakeDisplayValid/* && IsWindowFakeFullscreen(hWnd)*/ && VerifyIsTrustedCaller())
         {
             return (lpPoint != NULL);
         }

--- a/source/hooks/tls.h
+++ b/source/hooks/tls.h
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #pragma once
@@ -17,7 +17,6 @@ struct ThreadLocalStuff
 	BOOL isFrameThread;
 	BOOL isFirstThread;
 	BOOL createdFirstWindow;
-	LONG callerisuntrusted; // in this context "untrusted" means I can't trust it to be deterministic and behave the same between OS versions. was originally called "indefprochandler". TODO: may need to implement a way to ask the debugger to check the callstack to see if it's either my code or the game's code or some dll in the game's folder that's calling the current code, to catch cases where I have no entry function to hook.
 	LONG crawlHackDisableCount; // testing
 	LONG destroyWindowDepth;
 	BOOL callingClientLoadLibrary;
@@ -81,7 +80,6 @@ private:
 		isFrameThread = FALSE;
 		isFirstThread = FALSE;
 		createdFirstWindow = FALSE;
-		callerisuntrusted = 0;
 		crawlHackDisableCount = 0;
 		destroyWindowDepth = 0;
 		callingClientLoadLibrary = FALSE;

--- a/source/hooks/wintasee.h
+++ b/source/hooks/wintasee.h
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2011 nitsuja and contributors
+﻿/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 #pragma once
@@ -18,7 +18,7 @@ bool RedrawScreen();
 BOOL tls_IsPrimaryThread();
 BOOL tls_IsPrimaryThread2(struct ThreadLocalStuff* pCurTls);
 
-bool VerifyIsTrustedCaller(bool trusted);
+bool VerifyIsTrustedCaller();
 
 bool ShouldSkipDrawing(bool destIsFrontBuffer, bool destIsBackBuffer);
 

--- a/source/shared/ipc.h
+++ b/source/shared/ipc.h
@@ -159,8 +159,6 @@ namespace IPC
         CMD_INPUT_BUF_REPLY,
         CMD_DLL_LOAD_INFO_BUF,
         CMD_DLL_LOAD_INFO_BUF_REPLY,
-        CMD_TRUSTED_RANGE_INFO_BUF,
-        CMD_TRUSTED_RANGE_INFO_BUF_REPLY,
         CMD_TAS_FLAGS_BUF,
         CMD_TAS_FLAGS_BUF_REPLY,
         CMD_SOUND_INFO,
@@ -197,6 +195,8 @@ namespace IPC
         CMD_DENIED_THREAD_REPLY,
         CMD_STACK_TRACE,
         CMD_STACK_TRACE_REPLY,
+        CMD_IS_TRUSTED_CALLER,
+        CMD_IS_TRUSTED_CALLER_REPLY,
     };
 
     struct CommandFrame
@@ -204,6 +204,21 @@ namespace IPC
         Command m_command;
         DWORD m_command_data_size;
         LPCVOID m_command_data;
+    };
+
+    class TrustedCaller
+    {
+    public:
+        void SetTrusted(bool is_trusted)
+        {
+            m_trusted = is_trusted;
+        }
+        bool GetTrusted()
+        {
+            return m_trusted;
+        }
+    private:
+        bool m_trusted = false;
     };
 
     class FPSInfo


### PR DESCRIPTION
This makes the check safer as it doesn't rely on stack frames being within specific sizes.

Fixes issue #52 