### PR TITLE
Allow compilation with VS2017 15.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please format your pull request titles according to:
 When contributing, please adhere to the coding standard.  
 We know a lot of the code does not follow this standard, that's what happens when you fork a dead project, and then you're terrible at enforcing a standard for a while. This is _not_ an excuse to ignore the coding standard. If you have the time instead, please update existing code to follow the standard.
 
-You may use any version of Visual Studio for the development locally, but the master repo must be buildable with Visual Studio 2017 for the time being.
+The minimal supported version of Visual Studio is VS2017 Update 3 for the time being.
 
 Keep in mind that this project is aimed to work only with 32-bit programs and is dependant on 32-bit memory addressing to work. Therefore a lot of the coding standard is ignoring many problems that would arise compiling the code as a 64-bit program.
 

--- a/README.md
+++ b/README.md
@@ -17,4 +17,6 @@ Helping
 -------
 Hourglass-Resurrection is a big project, and as the original developer is no longer working on it, much of the code is not yet fully understood. There is still a lot of work to do, so any help you can offer is welcome. You don't have to be an expert coder to do this! Testing stability and functionality is just as welcome, just be detailed in the issue reports! Again, please refer to the [Hourglass section on TASVideos.org](http://tasvideos.org/forum/viewforum.php?f=61) for more information.
 
+For code contributions, please refer to the `CONTRIBUTING.md` file.
+
 We're also on IRC: #hourglass at irc.freenode.net. 

--- a/source/application/application.vcxproj
+++ b/source/application/application.vcxproj
@@ -77,7 +77,6 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalOptions>/SAFESEH %(AdditionalOptions)</AdditionalOptions>
@@ -120,7 +119,6 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalOptions>/permissive- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalOptions>/SAFESEH %(AdditionalOptions)</AdditionalOptions>
@@ -174,6 +172,7 @@
     <ClCompile Include="inject\process.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\shared\CompilerChecks.h" />
     <ClInclude Include="..\shared\input.h" />
     <ClInclude Include="AVIDumping\AudioConverterStream.h" />
     <ClInclude Include="AVIDumping\AVIDumper.h" />

--- a/source/application/application.vcxproj.filters
+++ b/source/application/application.vcxproj.filters
@@ -253,6 +253,9 @@
     <ClInclude Include="TrustedModule.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\shared\CompilerChecks.h">
+      <Filter>Source Files\shared</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="wintaser.rc" />

--- a/source/application/wintaser.cpp
+++ b/source/application/wintaser.cpp
@@ -1,4 +1,4 @@
-﻿/*  Copyright (C) 2011 nitsuja and contributors
+/*  Copyright (C) 2011 nitsuja and contributors
     Hourglass is licensed under GPL v2. Full notice is in COPYING.txt. */
 
 // main EXE cpp
@@ -74,6 +74,10 @@ using namespace Config;
 #include "DirLocks.h"
 #include "ExeFileOperations.h"
 #include "Utils/File.h"
+
+#include "shared/CompilerChecks.h"
+
+ABORT_ON_NEW_COMPILER("/permissive- was disabled due to a bug in VS2017.3, re-enable it now.");
 
 #pragma warning(disable:4995)
 

--- a/source/hooks/hooks.vcxproj
+++ b/source/hooks/hooks.vcxproj
@@ -76,7 +76,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalOptions>/Oy- /permissive- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
@@ -108,7 +108,7 @@
       </Message>
     </CustomBuildStep>
     <ClCompile>
-      <AdditionalOptions>/Oy- /permissive- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Oy- %(AdditionalOptions)</AdditionalOptions>
       <Optimization>MinSpace</Optimization>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
       <IntrinsicFunctions>false</IntrinsicFunctions>
@@ -184,6 +184,7 @@
     <ClCompile Include="hooks\windowhooks.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\shared\CompilerChecks.h" />
     <ClInclude Include="..\shared\input.h" />
     <ClInclude Include="dettime.h" />
     <ClInclude Include="global.h" />

--- a/source/hooks/hooks.vcxproj.filters
+++ b/source/hooks/hooks.vcxproj.filters
@@ -201,5 +201,8 @@
     <ClInclude Include="ipc.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\shared\CompilerChecks.h">
+      <Filter>Source Files\shared</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/source/hooks/tramps/soundtramps.h
+++ b/source/hooks/tramps/soundtramps.h
@@ -6,14 +6,17 @@
 #include "../intercept.h"
 #include "shared/ipc.h"
 
+struct IDirectSound;
+struct IDirectSound8;
+
 namespace Hooks
 {
     extern LastFrameSoundInfo lastFrameSoundInfo;
 
     namespace DirectSound
     {
-        HOOK_FUNCTION_DECLARE(HRESULT, WINAPI, DirectSoundCreate, LPCGUID pcGuidDevice, struct IDirectSound* *ppDS, LPUNKNOWN pUnkOuter);
-        HOOK_FUNCTION_DECLARE(HRESULT, WINAPI, DirectSoundCreate8, LPCGUID pcGuidDevice, struct IDirectSound8* *ppDS, LPUNKNOWN pUnkOuter);
+        HOOK_FUNCTION_DECLARE(HRESULT, WINAPI, DirectSoundCreate, LPCGUID pcGuidDevice, IDirectSound **ppDS, LPUNKNOWN pUnkOuter);
+        HOOK_FUNCTION_DECLARE(HRESULT, WINAPI, DirectSoundCreate8, LPCGUID pcGuidDevice, IDirectSound8 **ppDS, LPUNKNOWN pUnkOuter);
 
         typedef BOOL(CALLBACK *LPDSENUMCALLBACKA)(LPGUID, LPCSTR, LPCSTR, LPVOID);
         typedef BOOL(CALLBACK *LPDSENUMCALLBACKW)(LPGUID, LPCWSTR, LPCWSTR, LPVOID);

--- a/source/shared/CompilerChecks.h
+++ b/source/shared/CompilerChecks.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+/*
+ * This header provides various macros for "noisy" alerts on hacks applied due to
+ * compiler shortcomings.
+ */
+
+#define _CURRENTLY_USED_MSC_VER 1911
+
+static_assert(!(_MSC_VER < _CURRENTLY_USED_MSC_VER), "Your toolchain version is too old. Compilation aborted. Update Visual Studio.");
+
+#define ABORT_ON_NEW_COMPILER(str) \
+        static_assert(!(_MSC_VER > _CURRENTLY_USED_MSC_VER), str)


### PR DESCRIPTION
Fixes 2 issues.

* The function signatures for TrampDirectSoundCreate8 was broken, and went undetected. Corrected.
* [Disable /permissive- due to a 15.3 bug](https://developercommunity.visualstudio.com/content/problem/94419/vs-2017-153-with-permissive-shows-error-c2187-in-c.html)