### PR TITLE
EXE: Channel Windows exceptions through try-catch

### DIFF
--- a/source/application/AVIDumping/AVIDumper.cpp
+++ b/source/application/AVIDumping/AVIDumper.cpp
@@ -31,6 +31,9 @@
 #include "AudioConverterStream.h"
 #include "WaitableBool.h"
 
+#include "application/Utils/Exceptions.h"
+#include "application/Utils/Thread.h"
+
 extern bool tasFlagsDirty;
 
 // TODO: Eliminate this
@@ -69,11 +72,11 @@ HRESULT SafeAVIStreamWrite(PAVISTREAM pavi, LONG lStart, LONG lSamples, LPVOID l
 {
 	HRESULT hr;
 
-	__try
+	try
 	{
 		hr = AVIStreamWrite(pavi, lStart, lSamples, lpBuffer, cbBuffer, dwFlags, plSampWritten, plBytesWritten);
 	} 
-	__except(EXCEPTION_EXECUTE_HANDLER)
+	catch (const Utils::Exceptions::WindowsException&)
 	{
 		hr = E_POINTER;
 	}
@@ -152,9 +155,9 @@ struct AviFrameQueue
 		}
 
 		threadDone = false;
-		thread = CreateThread(NULL, 0, AviFrameQueue<numSlots>::OutputVideoThreadFunc, (void*)this, CREATE_SUSPENDED, NULL);
+		thread = Utils::Thread::CreateThread(NULL, 0, AviFrameQueue<numSlots>::OutputVideoThreadFunc, (void*)this, CREATE_SUSPENDED, NULL);
 		SetThreadPriority(thread, THREAD_PRIORITY_HIGHEST);
-		threadAudio = CreateThread(NULL, 0, AviFrameQueue<numSlots>::OutputAudioThreadFunc, (void*)this, CREATE_SUSPENDED, NULL);
+		threadAudio = Utils::Thread::CreateThread(NULL, 0, AviFrameQueue<numSlots>::OutputAudioThreadFunc, (void*)this, CREATE_SUSPENDED, NULL);
 		SetThreadPriority(threadAudio, THREAD_PRIORITY_ABOVE_NORMAL);
 		m_disableFills = false;
 		ResumeThread(thread);

--- a/source/application/Utils/Exceptions.h
+++ b/source/application/Utils/Exceptions.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <stdexcept>
+
+namespace Utils
+{
+    namespace Exceptions
+    {
+        class WindowsException : public std::runtime_error
+        {
+        public:
+            WindowsException(DWORD code, LPCSTR message);
+            DWORD code() const;
+        private:
+            DWORD m_code;
+        };
+
+        /*
+         * This must be called for each thread.
+         */
+        void InitWindowsExceptionsHandler();
+    }
+}

--- a/source/application/Utils/Exceptions/WindowsExceptionsHandler.cpp
+++ b/source/application/Utils/Exceptions/WindowsExceptionsHandler.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include <stdexcept>
+
+#include "../Exceptions.h"
+
+namespace
+{
+    static void WindowsExceptionHandler(unsigned int code, EXCEPTION_POINTERS*)
+    {
+        LPCSTR message;
+        switch (code)
+        {
+        case EXCEPTION_ACCESS_VIOLATION:
+            message = "The thread attempted to read from or write to a virtual address for which it does not have access.";
+            break;
+        case EXCEPTION_ARRAY_BOUNDS_EXCEEDED:
+            message = "The thread attempted to access an array element that is out of bounds.";
+            break;
+        case EXCEPTION_BREAKPOINT:
+            message = "A breakpoint was encountered.";
+            break;
+        case EXCEPTION_DATATYPE_MISALIGNMENT:
+            message = "The thread attempted to read or write data that is misaligned on hardware that does not provide alignment.";
+            break;
+        case EXCEPTION_FLT_DENORMAL_OPERAND:
+            message = "One of the operands in a floating point operation was denormal.";
+            break;
+        case EXCEPTION_FLT_DIVIDE_BY_ZERO:
+            message = "The thread attempted to divide a floating point value by a floating point divisor of 0 (zero).";
+            break;
+        case EXCEPTION_FLT_INEXACT_RESULT:
+            message = "The result of a floating point operation could not be represented exactly as a decimal fraction.";
+            break;
+        case EXCEPTION_FLT_INVALID_OPERATION:
+            message = "Invalid floating point operation.";
+            break;
+        case EXCEPTION_FLT_OVERFLOW:
+            message = "The exponent of a floating point operation was greater than the magnitude allowed by the corresponding type.";
+            break;
+        case EXCEPTION_FLT_STACK_CHECK:
+            message = "The stack overflowed or underflowed, because of a floating point operation.";
+            break;
+        case EXCEPTION_FLT_UNDERFLOW:
+            message = "The exponent of a floating point operation was less than the magnitude allowed by the corresponding type.";
+            break;
+        case EXCEPTION_GUARD_PAGE:
+            message = "The thread accessed memory allocated with the PAGE_GUARD modifier.";
+            break;
+        case EXCEPTION_ILLEGAL_INSTRUCTION:
+            message = "The thread tried to execute an invalid instruction.";
+            break;
+        case EXCEPTION_IN_PAGE_ERROR:
+            message = "The thread tried to access a page that is not present, and the system was unable to load the page.";
+            break;
+        case EXCEPTION_INT_DIVIDE_BY_ZERO:
+            message = "The thread attempted to divide an integer value by an integer divisor of 0 (zero).";
+            break;
+        case EXCEPTION_INT_OVERFLOW:
+            message = "The result of an integer operation created a value that was too large to be held by the destination register.";
+            break;
+        case EXCEPTION_INVALID_DISPOSITION:
+            message = "An exception handler returned an invalid disposition to the exception dispatcher.";
+            break;
+        case EXCEPTION_INVALID_HANDLE:
+            message = "The thread used a handle to a kernel object that was invalid. Probably because it has been closed.";
+            break;
+        case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+            message = "The thread attempted to continue execution after a non-continuable exception occured.";
+            break;
+        case EXCEPTION_PRIV_INSTRUCTION:
+            message = "The thread attempted to execute an instruction with an operation that is not allowed in the current computer mode.";
+            break;
+        case EXCEPTION_SINGLE_STEP:
+            message = "Trace trap or other single instruction mechanism signal.";
+            break;
+        case EXCEPTION_STACK_OVERFLOW:
+            message = "The thread used up its stack.";
+            break;
+        case STATUS_UNWIND_CONSOLIDATE:
+            message = "A frame consolidation was executed.";
+            break;
+        default:
+            message = "Unknown exception.";
+            break;
+        }
+        throw Utils::Exceptions::WindowsException(code, message);
+    }
+}
+
+Utils::Exceptions::WindowsException::WindowsException(DWORD code, LPCSTR message)
+    : std::runtime_error(message), m_code(code)
+{
+}
+
+DWORD Utils::Exceptions::WindowsException::code() const
+{
+    return m_code;
+}
+
+void Utils::Exceptions::InitWindowsExceptionsHandler()
+{
+    _set_se_translator(WindowsExceptionHandler);
+}

--- a/source/application/Utils/Thread.h
+++ b/source/application/Utils/Thread.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+namespace Utils
+{
+    namespace Thread
+    {
+        HANDLE CreateThread(LPSECURITY_ATTRIBUTES thread_attributes,
+                            SIZE_T stack_size,
+                            LPTHREAD_START_ROUTINE start_address,
+                            LPVOID parameter,
+                            DWORD creation_flags,
+                            LPDWORD thread_id);
+    }
+}

--- a/source/application/Utils/Thread/Thread.cpp
+++ b/source/application/Utils/Thread/Thread.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017- Hourglass Resurrection Team
+ * Hourglass Resurrection is licensed under GPL v2.
+ * Refer to the file COPYING.txt in the project root.
+ */
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#include "../Exceptions.h"
+
+#include "../Thread.h"
+
+namespace
+{
+    struct ThreadParams
+    {
+        LPTHREAD_START_ROUTINE function;
+        LPVOID param;
+    };
+
+    static DWORD WINAPI PreThreadProc(LPVOID param)
+    {
+        /*
+         * Init code for every thread.
+         */
+        Utils::Exceptions::InitWindowsExceptionsHandler();
+
+        /*
+         * Run actual thread proc.
+         */
+        ThreadParams* thread_params = reinterpret_cast<ThreadParams*>(param);
+        DWORD ret_code = thread_params->function(thread_params->param);
+        delete thread_params;
+        return ret_code;
+    }
+}
+
+HANDLE Utils::Thread::CreateThread(LPSECURITY_ATTRIBUTES thread_attributes, SIZE_T stack_size, LPTHREAD_START_ROUTINE start_address, LPVOID parameter, DWORD creation_flags, LPDWORD thread_id)
+{
+    /*
+     * Deleted by the PreThreadProc.
+     */
+    ThreadParams* thread_params = new ThreadParams();
+    thread_params->function = start_address;
+    thread_params->param = parameter;
+    return ::CreateThread(thread_attributes, stack_size, PreThreadProc, thread_params, creation_flags, thread_id);
+}

--- a/source/application/application.vcxproj
+++ b/source/application/application.vcxproj
@@ -77,6 +77,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <AdditionalOptions>/SAFESEH %(AdditionalOptions)</AdditionalOptions>
@@ -119,6 +120,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <ExceptionHandling>Async</ExceptionHandling>
     </ClCompile>
     <Link>
       <AdditionalOptions>/SAFESEH %(AdditionalOptions)</AdditionalOptions>
@@ -143,6 +145,7 @@
     <ClCompile Include="AVIDumping\WaitableBool.cpp" />
     <ClCompile Include="AVIDumping\WaveFormat.cpp" />
     <ClCompile Include="TrustedModule.cpp" />
+    <ClCompile Include="Utils\Exceptions\WindowsExceptionsHandler.cpp" />
     <ClCompile Include="Utils\File\ExecutableFileHeaders.cpp" />
     <ClCompile Include="Utils\File\FileDialog.cpp" />
     <ClCompile Include="Config.cpp" />
@@ -167,6 +170,7 @@
     <ClCompile Include="ramsearch.cpp" />
     <ClCompile Include="ramwatch.cpp" />
     <ClCompile Include="Utils\COM.cpp" />
+    <ClCompile Include="Utils\Thread\Thread.cpp" />
     <ClCompile Include="wintaser.cpp" />
     <ClCompile Include="inject\iatmodifier.cpp" />
     <ClCompile Include="inject\process.cpp" />
@@ -212,8 +216,10 @@
     <ClInclude Include="..\shared\winutil.h" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="TrustedModule.h" />
+    <ClInclude Include="Utils\Exceptions.h" />
     <ClInclude Include="Utils\File.h" />
     <ClInclude Include="Utils\COM.h" />
+    <ClInclude Include="Utils\Thread.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="wintaser.ico" />

--- a/source/application/application.vcxproj.filters
+++ b/source/application/application.vcxproj.filters
@@ -30,6 +30,12 @@
     <Filter Include="Source Files\Utils">
       <UniqueIdentifier>{73785f56-4309-4fed-b86c-ac56057f350b}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Utils\Exceptions">
+      <UniqueIdentifier>{551a5e3d-1d97-4c90-b837-310eab3a90a9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Utils\Thread">
+      <UniqueIdentifier>{a9554fd0-cd89-4fdc-ad98-782257099fe9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CustomDLGs.cpp">
@@ -127,6 +133,12 @@
     </ClCompile>
     <ClCompile Include="TrustedModule.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\Exceptions\WindowsExceptionsHandler.cpp">
+      <Filter>Source Files\Utils\Exceptions</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\Thread\Thread.cpp">
+      <Filter>Source Files\Utils\Thread</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -255,6 +267,12 @@
     </ClInclude>
     <ClInclude Include="..\shared\CompilerChecks.h">
       <Filter>Source Files\shared</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\Exceptions.h">
+      <Filter>Source Files\Utils</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\Thread.h">
+      <Filter>Source Files\Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Due to the compiler not allowing non-trivially destructible types in the same functions as a `__try`-`__except` block, channel the Windows exceptions through the `try`-`catch` handler instead, which allows it.

The logging overhaul PR #75 requires this, otherwise logging is not possible in functions that may trigger an exception.