### PR TITLE
Run tests on Appveyor

### DIFF
--- a/scripts/appveyor.yml
+++ b/scripts/appveyor.yml
@@ -14,5 +14,7 @@ after_build:
 - cmd: |-
     IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (SET PACKAGE="%APPVEYOR_PROJECT_NAME%-master") ELSE (SET PACKAGE="%APPVEYOR_PROJECT_NAME%-PR-%APPVEYOR_PULL_REQUEST_NUMBER%")
     7z a %PACKAGE%.zip %APPVEYOR_BUILD_FOLDER%\build\%CONFIGURATION%\*
+test_script:
+- build\tests\%CONFIGURATION%\test_runner\test_runner.exe
 artifacts:
 - path: '*zip'

--- a/source/test_runner/hourglass.cpp
+++ b/source/test_runner/hourglass.cpp
@@ -21,7 +21,11 @@ namespace Hourglass
 
     bool Find(const std::experimental::filesystem::path& base_path)
     {
+#ifdef NDEBUG
+        gs_hourglass_exe = base_path.parent_path().parent_path() / "Release" / "hourglass-resurrection.exe";
+#else
         gs_hourglass_exe = base_path.parent_path().parent_path() / "Debug" / "hourglass-resurrection-d.exe";
+#endif
 
         if (!filesystem::exists(gs_hourglass_exe))
         {


### PR DESCRIPTION
This also makes the Releases test runner test the Release build of Hourglass (which means that the Release build is also tested which is good, don't want any Release-specific bugs).

I'm expecting Appveyor to be unable to run any tests which involve actual graphics APIs, so tests like that, when added, will additionally need a switch in the test runner to only run some configured "appveyor-safe" list of tests.