### PR TITLE
Contributing: Replace Windows SDK rules with a target OS rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ Do not use implicit casts. Use explicit casts for assignment, comparisons and fu
 
 Anything local to a file shall be declared in an anonymous namespace.
 
+We're currently targetting Windows 7 and above. Ensure your code can run on Windows 7.
+
 Includes
 --------
 MSVC C++ header include guard style (`#pragma once`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,6 @@ Do not use implicit casts. Use explicit casts for assignment, comparisons and fu
 
 Anything local to a file shall be declared in an anonymous namespace.
 
-Make sure your code can, at least theoretically, compile with any Windows SDK from XP to most recent. Do try to check on MSDN for every used WinAPI function if it needs special includes etc. If there is a difference between header requirements between some versions of the Window SDKs, use proper `#ifdef` with Windows SDK defined values to handle it.
-
 Includes
 --------
 MSVC C++ header include guard style (`#pragma once`).


### PR DESCRIPTION
The text is obsolete now that we require VS2017 and XP support being dropped.